### PR TITLE
Allow title to be dynamically changed

### DIFF
--- a/src/lib/MetaTags.svelte
+++ b/src/lib/MetaTags.svelte
@@ -1,5 +1,5 @@
 <script>
-  export let title = undefined;
+  export let title = '';
   export let noindex = false;
   export let nofollow = false;
   export let robotsProps = undefined;
@@ -39,9 +39,7 @@
 </script>
 
 <svelte:head>
-  {#if title}
     <title>{title}</title>
-  {/if}
 
   <meta
     name="robots"


### PR DESCRIPTION
Complements #106 
For some reason svelte doesn't like the title in if blocks, according to https://stackoverflow.com/questions/59013329/best-place-lifecycle-method-to-set-page-titles-in-a-single-page-svelte-app