### PR TITLE
fix: add pnpm build to release command

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "cy:run": "cypress run",
     "test": "pnpm cy:run",
     "prepare": "husky install",
-    "release": "pnpm package && semantic-release"
+    "release": "pnpm build && pnpm package && semantic-release"
   },
   "dependencies": {
     "schema-dts": "1.1.0"


### PR DESCRIPTION
fix: https://github.com/oekazuma/svelte-meta-tags/issues/246