### PR TITLE
Clean up JSON-LD

### DIFF
--- a/src/lib/JsonLd.svelte
+++ b/src/lib/JsonLd.svelte
@@ -2,15 +2,15 @@
   export let output = 'head';
   export let schema = undefined;
 
-  const jsonSchema = (schema) => JSON.stringify({ '@context': 'https://schema.org', ...schema });
+  $: jsonSchema = JSON.stringify({ '@context': 'https://schema.org', ...schema });
 </script>
 
 <svelte:head>
   {#if schema && output === 'head'}
-    {@html `${'<scri' + 'pt type="application/ld+json">'}${jsonSchema(schema)}${'</scri' + 'pt>'}`}
+    {@html `${'<scri' + 'pt type="application/ld+json">'}${jsonSchema}${'</scri' + 'pt>'}`}
   {/if}
 </svelte:head>
 
 {#if schema && output === 'body'}
-  {@html `${'<scri' + 'pt type="application/ld+json">'}${jsonSchema(schema)}${'</scri' + 'pt>'}`}
+  {@html `${'<scri' + 'pt type="application/ld+json">'}${jsonSchema}${'</scri' + 'pt>'}`}
 {/if}

--- a/src/lib/JsonLd.svelte
+++ b/src/lib/JsonLd.svelte
@@ -1,16 +1,17 @@
 <script>
   export let output = 'head';
-  export let schema = undefined;
+  export let schema = {};
 
+  $: isValid = schema && typeof schema === 'object';
   $: json = `${'<scri' + 'pt type="application/ld+json">'}${JSON.stringify({ '@context': 'https://schema.org', ...schema })${'</scri' + 'pt>'}}`;
 </script>
 
 <svelte:head>
-  {#if schema && output === 'head'}
+  {#if isValid && output === 'head'}
     {@html json}
   {/if}
 </svelte:head>
 
-{#if schema && output === 'body'}
+{#if isValid && output === 'body'}
   {@html json}
 {/if}

--- a/src/lib/JsonLd.svelte
+++ b/src/lib/JsonLd.svelte
@@ -3,7 +3,10 @@
   export let schema = {};
 
   $: isValid = schema && typeof schema === 'object';
-  $: json = `${'<scri' + 'pt type="application/ld+json">'}${JSON.stringify({ '@context': 'https://schema.org', ...schema })}${'</scri' + 'pt>'}`;
+  $: json = `${'<scri' + 'pt type="application/ld+json">'}${JSON.stringify({
+    '@context': 'https://schema.org',
+    ...schema
+  })}${'</scri' + 'pt>'}`;
 </script>
 
 <svelte:head>

--- a/src/lib/JsonLd.svelte
+++ b/src/lib/JsonLd.svelte
@@ -3,7 +3,7 @@
   export let schema = {};
 
   $: isValid = schema && typeof schema === 'object';
-  $: json = `${'<scri' + 'pt type="application/ld+json">'}${JSON.stringify({ '@context': 'https://schema.org', ...schema })${'</scri' + 'pt>'}}`;
+  $: json = `${'<scri' + 'pt type="application/ld+json">'}${JSON.stringify({ '@context': 'https://schema.org', ...schema })}${'</scri' + 'pt>'}`;
 </script>
 
 <svelte:head>

--- a/src/lib/JsonLd.svelte
+++ b/src/lib/JsonLd.svelte
@@ -2,15 +2,15 @@
   export let output = 'head';
   export let schema = undefined;
 
-  $: jsonSchema = JSON.stringify({ '@context': 'https://schema.org', ...schema });
+  $: json = `${'<scri' + 'pt type="application/ld+json">'}${JSON.stringify({ '@context': 'https://schema.org', ...schema })${'</scri' + 'pt>'}}`;
 </script>
 
 <svelte:head>
   {#if schema && output === 'head'}
-    {@html `${'<scri' + 'pt type="application/ld+json">'}${jsonSchema}${'</scri' + 'pt>'}`}
+    {@html json}
   {/if}
 </svelte:head>
 
 {#if schema && output === 'body'}
-  {@html `${'<scri' + 'pt type="application/ld+json">'}${jsonSchema}${'</scri' + 'pt>'}`}
+  {@html json}
 {/if}


### PR DESCRIPTION
`JsonLd.svelte` had a couple tiny issues that I decided to clean up.
- Repeated strings to create the `<script>` element for body and head.
- Unnecessary arrow function to create JSON content.

My commits are:
- [x] Tested
- [x] Linted
- [x] Formatted