### PR TITLE
chore: set `workbench.editor.labelFormat` in VSCode to `short`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "workbench.editor.labelFormat": "short"
+}


### PR DESCRIPTION
https://twitter.com/oneeezy/status/1559668013200293891