### PR TITLE
feat: remove the `googlebot` tag

### DIFF
--- a/.changeset/spicy-papayas-sing.md
+++ b/.changeset/spicy-papayas-sing.md
@@ -1,0 +1,5 @@
+---
+'svelte-meta-tags': major
+---
+
+feat: remove the `googlebot` tag

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 jobs:
   ci:

--- a/src/lib/MetaTags.svelte
+++ b/src/lib/MetaTags.svelte
@@ -68,10 +68,6 @@
   <title>{updatedTitle}</title>
 
   <meta name="robots" content={`${noindex ? 'noindex' : 'index'},${nofollow ? 'nofollow' : 'follow'}${robotsParams}`} />
-  <meta
-    name="googlebot"
-    content={`${noindex ? 'noindex' : 'index'},${nofollow ? 'nofollow' : 'follow'}${robotsParams}`}
-  />
 
   {#if description}
     <meta name="description" content={description} />

--- a/src/routes/another/+page.svelte
+++ b/src/routes/another/+page.svelte
@@ -50,6 +50,10 @@
     {
       httpEquiv: 'x-ua-compatible',
       content: 'IE=edge; chrome=1'
+    },
+    {
+      name: 'googlebot',
+      content: 'noindex,nofollow'
     }
   ]}
 />

--- a/tests/jsonLdArray.test.ts
+++ b/tests/jsonLdArray.test.ts
@@ -9,7 +9,6 @@ test('JSON-LD Array SEO loads correctly', async ({ page }) => {
     'Description of JSON-LD Array page'
   );
   await expect(page.locator('head meta[name="robots"]')).toHaveAttribute('content', 'index,follow');
-  await expect(page.locator('head meta[name="googlebot"]')).toHaveAttribute('content', 'index,follow');
   const jsonLd = await page
     .locator('script[type="application/ld+json"]')
     .evaluateAll((list) => list.map((element) => element.textContent));

--- a/tests/jsonLdBody.test.ts
+++ b/tests/jsonLdBody.test.ts
@@ -9,7 +9,6 @@ test('JSON-LD Head SEO loads correctly', async ({ page }) => {
     'Description of JSON-LD Body page'
   );
   await expect(page.locator('head meta[name="robots"]')).toHaveAttribute('content', 'index,follow');
-  await expect(page.locator('head meta[name="googlebot"]')).toHaveAttribute('content', 'index,follow');
   const jsonLd = await page
     .locator('script[type="application/ld+json"]')
     .evaluateAll((list) => list.map((element) => element.textContent));

--- a/tests/jsonLdHead.test.ts
+++ b/tests/jsonLdHead.test.ts
@@ -9,7 +9,6 @@ test('JSON-LD Head SEO loads correctly', async ({ page }) => {
     'Description of JSON-LD Head page'
   );
   await expect(page.locator('head meta[name="robots"]')).toHaveAttribute('content', 'index,follow');
-  await expect(page.locator('head meta[name="googlebot"]')).toHaveAttribute('content', 'index,follow');
   const jsonLd = await page
     .locator('head script[type="application/ld+json"]')
     .evaluateAll((list) => list.map((element) => element.textContent));

--- a/tests/normal.test.ts
+++ b/tests/normal.test.ts
@@ -7,7 +7,6 @@ test('Normal SEO loads correctly', async ({ page, baseURL }) => {
   await expect(page.locator('head meta[name="description"]')).toHaveAttribute('content', 'Description');
   await expect(page.locator('head link[rel="canonical"]')).toHaveAttribute('href', 'https://www.canonical.ie/');
   await expect(page.locator('head meta[name="robots"]')).toHaveAttribute('content', 'index,follow');
-  await expect(page.locator('head meta[name="googlebot"]')).toHaveAttribute('content', 'index,follow');
   await expect(page.locator('head meta[property="og:type"]')).toHaveAttribute('content', 'website');
   await expect(page.locator('head meta[property="og:locale"]')).toHaveAttribute('content', 'en_IE');
   await expect(page.locator('head meta[property="og:url"]')).toHaveAttribute('content', 'https://www.example.com/page');

--- a/tests/robots.test.ts
+++ b/tests/robots.test.ts
@@ -8,8 +8,4 @@ test('Robots props SEO applied correctly', async ({ page }) => {
     'content',
     'index,follow,nosnippet,max-snippet:-1,max-image-preview:none,noarchive,noimageindex,max-video-preview:-1,notranslate'
   );
-  await expect(page.locator('head meta[name="googlebot"]')).toHaveAttribute(
-    'content',
-    'index,follow,nosnippet,max-snippet:-1,max-image-preview:none,noarchive,noimageindex,max-video-preview:-1,notranslate'
-  );
 });


### PR DESCRIPTION
In most cases, remove the `googlebot` tag so that it is not included by default since it is not needed.

If you wish to continue using the `googlebot` tag, please add the following.
```svelte
<MetaTags
  additionalMetaTags={[
    {
      name: 'googlebot',
      content: 'index,follow'
    }
  ]}
/>
```