### PR TITLE
Improved type definitions

### DIFF
--- a/.changeset/rare-candles-add.md
+++ b/.changeset/rare-candles-add.md
@@ -1,0 +1,5 @@
+---
+'svelte-meta-tags': major
+---
+
+feat: Improved type definitions

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ pnpm add -D svelte-meta-tags
 | `openGraph.description`            | string                                     | The open graph description, which may be different from your meta description                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 | `openGraph.images`                 | array                                      | An array of images to use as previews. If multiple are provided, you can choose one when sharing [See Examples](#open-graph-examples)                                                                                                                                                                                                                                                                                                                                                                                                 |
 | `openGraph.videos`                 | array                                      | An array of videos (object)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `openGraph.audio`                  | array                                      | An array of audio(object)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | `openGraph.locale`                 | string                                     | The locale in which the open graph tags are highlighted                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | `openGraph.site_name`              | string                                     | If your item is part of a larger website, the name that should be displayed for the entire site                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | `openGraph.profile.firstName`      | string                                     | Person's first name                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
@@ -942,8 +943,9 @@ interface OpenGraph {
   type?: string;
   title?: string;
   description?: string;
-  images?: ReadonlyArray<OpenGraphImages>;
-  videos?: ReadonlyArray<OpenGraphVideos>;
+  images?: ReadonlyArray<OpenGraphMedia>;
+  videos?: ReadonlyArray<OpenGraphMedia>;
+  audio?: ReadonlyArray<OpenGraphMedia>;
   locale?: string;
   site_name?: string;
   profile?: OpenGraphProfile;
@@ -965,9 +967,14 @@ type MetaTag = HTML5MetaTag | RDFaMetaTag | HTTPEquivMetaTag;
 interface LinkTag {
   rel: string;
   href: string;
+  hrefLang?: string;
+  media?: string;
   sizes?: string;
   type?: string;
   color?: string;
+  as?: string;
+  crossOrigin?: string;
+  referrerPolicy?: string;
 }
 ```
 
@@ -975,27 +982,16 @@ interface LinkTag {
 
 The following are referenced by the public types documented above, but cannot be imported directly
 
-### OpenGraphImages
+### OpenGraphMedia
 
 ```ts
-interface OpenGraphImages {
+interface OpenGraphMedia {
   url: string;
-  alt?: string;
   width?: number;
   height?: number;
-}
-```
-
-### OpenGraphVideos
-
-```ts
-interface OpenGraphVideos {
-  url: string;
   alt?: string;
-  width?: number;
-  height?: number;
-  secureUrl?: string;
   type?: string;
+  secureUrl?: string;
 }
 ```
 

--- a/packages/svelte-meta-tags/src/lib/JsonLd.svelte
+++ b/packages/svelte-meta-tags/src/lib/JsonLd.svelte
@@ -1,20 +1,16 @@
-<script>
-  /** @type {import("./types").JsonLdProps['output']} */
-  export let output = 'head';
+<script lang="ts">
+  import type { JsonLdProps } from './types';
 
-  /** @type {import("./types").JsonLdProps['schema']} */
-  export let schema = undefined;
+  export let output: JsonLdProps['output'] = 'head';
+  export let schema: JsonLdProps['schema'] = undefined;
 
   $: isValid = schema && typeof schema === 'object';
 
-  /**
-   * @param {import("./types").JsonLdProps['schema']} schema
-   */
-  function createSchema(schema) {
+  const createSchema = (schema: JsonLdProps['schema']) => {
     const addContext = (context) => ({ '@context': 'https://schema.org', ...context });
 
     return Array.isArray(schema) ? schema.map((context) => addContext(context)) : addContext(schema);
-  }
+  };
 
   $: json = `${'<scri' + 'pt type="application/ld+json">'}${JSON.stringify(createSchema(schema))}${'</scri' + 'pt>'}`;
 </script>

--- a/packages/svelte-meta-tags/src/lib/JsonLd.svelte
+++ b/packages/svelte-meta-tags/src/lib/JsonLd.svelte
@@ -5,9 +5,9 @@
   export let output: JsonLdProps['output'] = 'head';
   export let schema: JsonLdProps['schema'] = undefined;
 
-  $: isValid = schema && typeof schema === 'object';
-
   type OmitContext<T> = Omit<T, '@context'>;
+
+  $: isValid = schema && typeof schema === 'object';
 
   const createSchema = (schema: JsonLdProps['schema']) => {
     const addContext = (context: OmitContext<Thing> | OmitContext<WithContext<Thing>>) => ({

--- a/packages/svelte-meta-tags/src/lib/JsonLd.svelte
+++ b/packages/svelte-meta-tags/src/lib/JsonLd.svelte
@@ -1,15 +1,23 @@
 <script lang="ts">
   import type { JsonLdProps } from './types';
+  import type { Thing, WithContext } from 'schema-dts';
 
   export let output: JsonLdProps['output'] = 'head';
   export let schema: JsonLdProps['schema'] = undefined;
 
   $: isValid = schema && typeof schema === 'object';
 
-  const createSchema = (schema: JsonLdProps['schema']) => {
-    const addContext = (context) => ({ '@context': 'https://schema.org', ...context });
+  type OmitContext<T> = Omit<T, '@context'>;
 
-    return Array.isArray(schema) ? schema.map((context) => addContext(context)) : addContext(schema);
+  const createSchema = (schema: JsonLdProps['schema']) => {
+    const addContext = (context: OmitContext<Thing> | OmitContext<WithContext<Thing>>) => ({
+      '@context': 'https://schema.org',
+      ...context
+    });
+
+    return Array.isArray(schema)
+      ? schema.map((context) => addContext(context as OmitContext<Thing>))
+      : addContext(schema as OmitContext<WithContext<Thing>>);
   };
 
   $: json = `${'<scri' + 'pt type="application/ld+json">'}${JSON.stringify(createSchema(schema))}${'</scri' + 'pt>'}`;

--- a/packages/svelte-meta-tags/src/lib/MetaTags.svelte
+++ b/packages/svelte-meta-tags/src/lib/MetaTags.svelte
@@ -1,44 +1,21 @@
-<script>
-  /** @type {import("./types").MetaTagsProps['title']} */
-  export let title = '';
+<script lang="ts">
+  import type { MetaTagsProps } from './types';
 
-  /** @type {import("./types").MetaTagsProps['titleTemplate']} */
-  export let titleTemplate = '';
+  export let title: MetaTagsProps['title'] = '';
+  export let titleTemplate: MetaTagsProps['titleTemplate'] = '';
+  export let robots: MetaTagsProps['robots'] = 'index,follow';
+  export let additionalRobotsProps: MetaTagsProps['additionalRobotsProps'] = undefined;
+  export let description: MetaTagsProps['description'] = undefined;
+  export let mobileAlternate: MetaTagsProps['mobileAlternate'] = undefined;
+  export let languageAlternates: MetaTagsProps['languageAlternates'] = undefined;
+  export let twitter: MetaTagsProps['twitter'] = undefined;
+  export let facebook: MetaTagsProps['facebook'] = undefined;
+  export let openGraph: MetaTagsProps['openGraph'] = undefined;
+  export let canonical: MetaTagsProps['canonical'] = undefined;
+  export let additionalMetaTags: MetaTagsProps['additionalRobotsProps'] = undefined;
+  export let additionalLinkTags: MetaTagsProps['additionalLinkTags'] = undefined;
 
-  /** @type {import("./types").MetaTagsProps['robots']} */
-  export let robots = 'index,follow';
-
-  /** @type {import("./types").MetaTagsProps['additionalRobotsProps']} */
-  export let additionalRobotsProps = undefined;
-
-  /** @type {import("./types").MetaTagsProps['description']} */
-  export let description = undefined;
-
-  /** @type {import("./types").MetaTagsProps['mobileAlternate']} */
-  export let mobileAlternate = undefined;
-
-  /** @type {import("./types").MetaTagsProps['languageAlternates']} */
-  export let languageAlternates = undefined;
-
-  /** @type {import("./types").MetaTagsProps['twitter']} */
-  export let twitter = undefined;
-
-  /** @type {import("./types").MetaTagsProps['facebook']} */
-  export let facebook = undefined;
-
-  /** @type {import("./types").MetaTagsProps['openGraph']} */
-  export let openGraph = undefined;
-
-  /** @type {import("./types").MetaTagsProps['canonical']} */
-  export let canonical = undefined;
-
-  /** @type {import("./types").MetaTagsProps['additionalMetaTags']} */
-  export let additionalMetaTags = undefined;
-
-  /** @type {import("./types").MetaTagsProps['additionalLinkTags']} */
-  export let additionalLinkTags = undefined;
-
-  $: updatedTitle = titleTemplate ? titleTemplate.replace(/%s/g, title) : title;
+  $: updatedTitle = titleTemplate ? (title ? titleTemplate.replace(/%s/g, title) : title) : title;
 
   let robotsParams = '';
   if (additionalRobotsProps) {
@@ -190,7 +167,7 @@
           {/each}
         {/if}
       {:else if openGraph.type.toLowerCase() === 'video.movie' || openGraph.type.toLowerCase() === 'video.episode' || openGraph.type.toLowerCase() === 'video.tv_show' || (openGraph.type.toLowerCase() === 'video.other' && openGraph.video)}
-        {#if openGraph.video.actors && openGraph.video.actors.length}
+        {#if openGraph.video?.actors && openGraph.video.actors.length}
           {#each openGraph.video.actors as actor}
             {#if actor.profile}
               <meta property="video:actor" content={actor.profile} />
@@ -201,33 +178,33 @@
           {/each}
         {/if}
 
-        {#if openGraph.video.directors && openGraph.video.directors.length}
+        {#if openGraph.video?.directors && openGraph.video.directors.length}
           {#each openGraph.video.directors as director}
             <meta property="video:director" content={director} />
           {/each}
         {/if}
 
-        {#if openGraph.video.writers && openGraph.video.writers.length}
+        {#if openGraph.video?.writers && openGraph.video.writers.length}
           {#each openGraph.video.writers as writer}
             <meta property="video:writer" content={writer} />
           {/each}
         {/if}
 
-        {#if openGraph.video.duration}
+        {#if openGraph.video?.duration}
           <meta property="video:duration" content={openGraph.video.duration.toString()} />
         {/if}
 
-        {#if openGraph.video.releaseDate}
+        {#if openGraph.video?.releaseDate}
           <meta property="video:release_date" content={openGraph.video.releaseDate} />
         {/if}
 
-        {#if openGraph.video.tags && openGraph.video.tags.length}
+        {#if openGraph.video?.tags && openGraph.video.tags.length}
           {#each openGraph.video.tags as tag}
             <meta property="video:tag" content={tag} />
           {/each}
         {/if}
 
-        {#if openGraph.video.series}
+        {#if openGraph.video?.series}
           <meta property="video:series" content={openGraph.video.series} />
         {/if}
       {/if}
@@ -286,7 +263,7 @@
     {/if}
   {/if}
 
-  {#if additionalMetaTags && additionalMetaTags.length > 0}
+  {#if additionalMetaTags && Object.keys(additionalMetaTags).length > 0}
     {#each additionalMetaTags as tag}
       <meta {...tag} />
     {/each}

--- a/packages/svelte-meta-tags/src/lib/MetaTags.svelte
+++ b/packages/svelte-meta-tags/src/lib/MetaTags.svelte
@@ -263,7 +263,7 @@
     {/if}
   {/if}
 
-  {#if additionalMetaTags && Object.keys(additionalMetaTags).length > 0}
+  {#if additionalMetaTags && Array.isArray(additionalMetaTags)}
     {#each additionalMetaTags as tag}
       <meta {...tag} />
     {/each}

--- a/packages/svelte-meta-tags/src/lib/types.d.ts
+++ b/packages/svelte-meta-tags/src/lib/types.d.ts
@@ -40,8 +40,9 @@ export interface OpenGraph {
   type?: string;
   title?: string;
   description?: string;
-  images?: ReadonlyArray<OpenGraphImages>;
-  videos?: ReadonlyArray<OpenGraphVideos>;
+  images?: ReadonlyArray<OpenGraphMedia>;
+  videos?: ReadonlyArray<OpenGraphMedia>;
+  audio?: ReadonlyArray<OpenGraphMedia>;
   locale?: string;
   site_name?: string;
   profile?: OpenGraphProfile;
@@ -50,20 +51,13 @@ export interface OpenGraph {
   video?: OpenGraphVideo;
 }
 
-interface OpenGraphImages {
+interface OpenGraphMedia {
   url: string;
-  alt?: string;
   width?: number;
   height?: number;
-}
-
-interface OpenGraphVideos {
-  url: string;
   alt?: string;
-  width?: number;
-  height?: number;
-  secureUrl?: string;
   type?: string;
+  secureUrl?: string;
 }
 
 interface OpenGraphProfile {
@@ -131,9 +125,14 @@ export type MetaTag = HTML5MetaTag | RDFaMetaTag | HTTPEquivMetaTag;
 export interface LinkTag {
   rel: string;
   href: string;
+  hrefLang?: string;
+  media?: string;
   sizes?: string;
   type?: string;
   color?: string;
+  as?: string;
+  crossOrigin?: string;
+  referrerPolicy?: string;
 }
 
 export interface MetaTagsProps {

--- a/packages/svelte-meta-tags/src/lib/types.d.ts
+++ b/packages/svelte-meta-tags/src/lib/types.d.ts
@@ -20,6 +20,7 @@ export interface AdditionalRobotsProps {
   noimageindex?: boolean;
   notranslate?: boolean;
 }
+
 export interface Twitter {
   cardType?: 'summary' | 'summary_large_image' | 'app' | 'player';
   site?: string;
@@ -48,12 +49,14 @@ export interface OpenGraph {
   article?: OpenGraphArticle;
   video?: OpenGraphVideo;
 }
+
 interface OpenGraphImages {
   url: string;
   alt?: string;
   width?: number;
   height?: number;
 }
+
 interface OpenGraphVideos {
   url: string;
   alt?: string;
@@ -62,6 +65,7 @@ interface OpenGraphVideos {
   secureUrl?: string;
   type?: string;
 }
+
 interface OpenGraphProfile {
   firstName?: string;
   lastName?: string;
@@ -75,6 +79,7 @@ interface OpenGraphBook {
   releaseDate?: string;
   tags?: ReadonlyArray<string>;
 }
+
 interface OpenGraphArticle {
   publishedTime?: string;
   modifiedTime?: string;

--- a/packages/svelte-meta-tags/tsconfig.json
+++ b/packages/svelte-meta-tags/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "strict": true
   }
 }

--- a/tests/v3/tests/robotsAnother.test.ts
+++ b/tests/v3/tests/robotsAnother.test.ts
@@ -1,6 +1,10 @@
 import { test, expect } from '@playwright/test';
 
-const checkConsoleMessagesFor = (expectedMessage) => (msg) => {
+interface Message {
+  text(): string;
+}
+
+const checkConsoleMessagesFor = (expectedMessage: string) => (msg: Message) => {
   return msg.text().includes(expectedMessage);
 };
 

--- a/tests/v3/tsconfig.json
+++ b/tests/v3/tsconfig.json
@@ -8,6 +8,6 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "sourceMap": true,
-    "strict": true,
+    "strict": true
   }
 }

--- a/tests/v3/tsconfig.json
+++ b/tests/v3/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "strict": true,
   }
 }

--- a/tests/v4/tests/robotsAnother.test.ts
+++ b/tests/v4/tests/robotsAnother.test.ts
@@ -1,6 +1,10 @@
 import { test, expect } from '@playwright/test';
 
-const checkConsoleMessagesFor = (expectedMessage) => (msg) => {
+interface Message {
+  text(): string;
+}
+
+const checkConsoleMessagesFor = (expectedMessage: string) => (msg: Message) => {
   return msg.text().includes(expectedMessage);
 };
 

--- a/tests/v4/tsconfig.json
+++ b/tests/v4/tsconfig.json
@@ -8,6 +8,6 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "sourceMap": true,
-    "strict": true,
+    "strict": true
   }
 }

--- a/tests/v4/tsconfig.json
+++ b/tests/v4/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "strict": true,
   }
 }


### PR DESCRIPTION
fix: https://github.com/oekazuma/svelte-meta-tags/issues/796
This is expected to improve type safety.