### PR TITLE
Fix to not generate an empty `<title>` tag if no title is set

### DIFF
--- a/.changeset/bright-grapes-brush.md
+++ b/.changeset/bright-grapes-brush.md
@@ -1,0 +1,5 @@
+---
+"svelte-meta-tags": patch
+---
+
+Fix to not generate an empty `<title>` tag if no title is set

--- a/.changeset/bright-grapes-brush.md
+++ b/.changeset/bright-grapes-brush.md
@@ -1,5 +1,5 @@
 ---
-"svelte-meta-tags": patch
+'svelte-meta-tags': patch
 ---
 
 Fix to not generate an empty `<title>` tag if no title is set

--- a/packages/svelte-meta-tags/src/lib/MetaTags.svelte
+++ b/packages/svelte-meta-tags/src/lib/MetaTags.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { MetaTagsProps } from './types';
+import type { MetaTagsProps } from './types';
 
   export let title: MetaTagsProps['title'] = '';
   export let titleTemplate: MetaTagsProps['titleTemplate'] = '';
@@ -44,7 +44,9 @@
 </script>
 
 <svelte:head>
-  <title>{updatedTitle}</title>
+  {#if updatedTitle}
+    <title>{updatedTitle}</title>
+  {/if}
 
   {#if robots !== false}
     <meta name="robots" content="{robots}{robotsParams}" />

--- a/packages/svelte-meta-tags/src/lib/MetaTags.svelte
+++ b/packages/svelte-meta-tags/src/lib/MetaTags.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { MetaTagsProps } from './types';
+  import type { MetaTagsProps } from './types';
 
   export let title: MetaTagsProps['title'] = '';
   export let titleTemplate: MetaTagsProps['titleTemplate'] = '';

--- a/tests/svelte-3/src/routes/another/+page.svelte
+++ b/tests/svelte-3/src/routes/another/+page.svelte
@@ -3,7 +3,8 @@
 </script>
 
 <MetaTags
-  title="Another | Svelte Meta Tags"
+  title=""
+  titleTemplate="%s | Svelte Meta Tags"
   robots="noindex,nofollow"
   description="Description Another"
   canonical="https://www.canonical.ie/another"

--- a/tests/svelte-3/tests/another.test.ts
+++ b/tests/svelte-3/tests/another.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 
 test('Another pattern SEO loads correctly', async ({ page }) => {
   await page.goto('/another');
-  await expect(page).toHaveTitle('Another | Svelte Meta Tags');
+  await expect(page).toHaveTitle('');
   await expect(page.locator('h1')).toContainText('Another SEO');
   await expect(page.locator('head meta[name="description"]')).toHaveAttribute('content', 'Description Another');
   await expect(page.locator('head link[rel="canonical"]')).toHaveAttribute('href', 'https://www.canonical.ie/another');

--- a/tests/svelte-4/src/routes/another/+page.svelte
+++ b/tests/svelte-4/src/routes/another/+page.svelte
@@ -3,7 +3,8 @@
 </script>
 
 <MetaTags
-  title="Another | Svelte Meta Tags"
+  title=""
+  titleTemplate="%s | Svelte Meta Tags"
   robots="noindex,nofollow"
   description="Description Another"
   canonical="https://www.canonical.ie/another"

--- a/tests/svelte-4/tests/another.test.ts
+++ b/tests/svelte-4/tests/another.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 
 test('Another pattern SEO loads correctly', async ({ page }) => {
   await page.goto('/another');
-  await expect(page).toHaveTitle('Another | Svelte Meta Tags');
+  await expect(page).toHaveTitle('');
   await expect(page.locator('h1')).toContainText('Another SEO');
   await expect(page.locator('head meta[name="description"]')).toHaveAttribute('content', 'Description Another');
   await expect(page.locator('head link[rel="canonical"]')).toHaveAttribute('href', 'https://www.canonical.ie/another');


### PR DESCRIPTION
fix: https://github.com/oekazuma/svelte-meta-tags/issues/975