### PR TITLE
fix: add title to Link type

### DIFF
--- a/.changeset/swift-ravens-perform.md
+++ b/.changeset/swift-ravens-perform.md
@@ -1,0 +1,5 @@
+---
+'svelte-meta-tags': patch
+---
+
+add title attribute to Link type

--- a/packages/svelte-meta-tags/src/lib/types.d.ts
+++ b/packages/svelte-meta-tags/src/lib/types.d.ts
@@ -140,6 +140,7 @@ export interface LinkTag {
   rel: string;
   href: string;
   hrefLang?: string;
+  title?: string;
   media?: string;
   sizes?: string;
   type?: string;


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#title
I found that `title` is missing in <link> tag!