### PR TITLE
fix: Allow nullable values in `deepMerge`

### DIFF
--- a/.changeset/shy-pillows-do.md
+++ b/.changeset/shy-pillows-do.md
@@ -1,0 +1,5 @@
+---
+'svelte-meta-tags': minor
+---
+
+Allow nullable values in `deepMerge`

--- a/packages/svelte-meta-tags/src/lib/deepMerge.ts
+++ b/packages/svelte-meta-tags/src/lib/deepMerge.ts
@@ -1,5 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-export const deepMerge = <X extends Record<string | symbol | number, any>>(target: X, source: X): X => {
+export const deepMerge = <X extends Record<string | symbol | number, any>>(
+  target: X | null | undefined,
+  source: X | null | undefined
+): X => {
   if (!target || !source) return target ?? source ?? ({} as X);
 
   const result: Record<string | symbol | number, any> = { ...target };


### PR DESCRIPTION
The function should and does aptly handle null values. This fixes the TypeScript type annotations to allow it.