### PR TITLE
docs(readme): add users info

### DIFF
--- a/.github/workflows/dependents.yml
+++ b/.github/workflows/dependents.yml
@@ -1,0 +1,16 @@
+name: Dependents Action
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 0 1 * *"
+  workflow_dispatch:
+
+jobs:
+  dependents:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: gouravkhunger/dependents.info@0.1.4

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <img src="https://raw.githubusercontent.com/oekazuma/svelte-meta-tags/main/.github/logo.svg" alt="svelte-meta-tags" width="512" />
 
 [![CI](https://github.com/oekazuma/svelte-meta-tags/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/oekazuma/svelte-meta-tags/actions/workflows/ci.yml)
+[![Network Dependents](https://dependents.info/oekazuma/svelte-meta-tags/badge?label=users)](https://dependents.info/oekazuma/svelte-meta-tags)
 [![download](https://img.shields.io/npm/dt/svelte-meta-tags.svg)](https://www.npmjs.com/package/svelte-meta-tags)
 [![npm](https://img.shields.io/npm/v/svelte-meta-tags)](https://www.npmjs.com/package/svelte-meta-tags)
 [![MIT](https://img.shields.io/npm/l/svelte-meta-tags)](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
Hi @oekazuma!

Thank you for this awesome project! This PR adds a relevant auto-updated shields.io style network dependents badge and the image in the `README.md` file to showcase its impact.

I've created this using an [open source](https://github.com/gouravkhunger/dependents.info) tool I built some time ago and plan to maintain for long. It also creates an image preview of the users in the readme.

Here's how they would look for your repository:

<img width="680" height="145" alt="image" src="https://github.com/user-attachments/assets/d604a3fc-e632-4c44-8a26-e8e1b7d8512e" />

I have not included the full users image to keep the readme minimal.

Please feel free to close the PR if you don't want to have this!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new workflow to track and display repository dependents.
* **Documentation**
  * Introduced a "Network Dependents" badge in the README, showing the number of users depending on the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->