### PR TITLE
fix: type compatibility issue where schema-dts WithContext<T> types (e.g., WithContext<VideoObject>) were not assignable to JsonLdProps.schema

### DIFF
--- a/.changeset/chubby-coins-stop.md
+++ b/.changeset/chubby-coins-stop.md
@@ -1,0 +1,5 @@
+---
+'svelte-meta-tags': patch
+---
+
+fix: type compatibility issue where schema-dts WithContext<T> types (e.g., WithContext<VideoObject>) were not assignable to JsonLdProps.schema

--- a/docs/src/content/docs/ja/types/json-ld-props.md
+++ b/docs/src/content/docs/ja/types/json-ld-props.md
@@ -7,6 +7,11 @@ sidebar:
 ```ts
 interface JsonLdProps {
   output?: 'head' | 'body';
-  schema?: WithInputOutputProperties<FlexibleSchema> | WithInputOutputProperties<FlexibleSchema>[] | GraphWrappedThing;
+  schema?:
+    | FlexibleSchema
+    | WithInputOutputProperties<FlexibleSchema>
+    | FlexibleSchema[]
+    | WithInputOutputProperties<FlexibleSchema>[]
+    | GraphWrappedThing;
 }
 ```

--- a/docs/src/content/docs/types/json-ld-props.md
+++ b/docs/src/content/docs/types/json-ld-props.md
@@ -7,6 +7,11 @@ sidebar:
 ```ts
 interface JsonLdProps {
   output?: 'head' | 'body';
-  schema?: WithInputOutputProperties<FlexibleSchema> | WithInputOutputProperties<FlexibleSchema>[] | GraphWrappedThing;
+  schema?:
+    | FlexibleSchema
+    | WithInputOutputProperties<FlexibleSchema>
+    | FlexibleSchema[]
+    | WithInputOutputProperties<FlexibleSchema>[]
+    | GraphWrappedThing;
 }
 ```

--- a/packages/svelte-meta-tags/src/lib/types.d.ts
+++ b/packages/svelte-meta-tags/src/lib/types.d.ts
@@ -10,7 +10,11 @@ type JsonLdSchema = Record<string, unknown> & {
   '@id'?: string;
 };
 
-type FlexibleSchema = JsonLdSchema | (Thing & Record<string, unknown>) | (WithContext<Thing> & Record<string, unknown>);
+type FlexibleSchema =
+  | JsonLdSchema
+  | (Thing & Record<string, unknown>)
+  | (WithContext<Thing> & Record<string, unknown>)
+  | WithContext<Thing>;
 
 export interface MobileAlternate {
   media: string;
@@ -229,5 +233,10 @@ interface GraphWrappedThing {
 
 export interface JsonLdProps {
   output?: 'head' | 'body';
-  schema?: WithInputOutputProperties<FlexibleSchema> | WithInputOutputProperties<FlexibleSchema>[] | GraphWrappedThing;
+  schema?:
+    | FlexibleSchema
+    | WithInputOutputProperties<FlexibleSchema>
+    | FlexibleSchema[]
+    | WithInputOutputProperties<FlexibleSchema>[]
+    | GraphWrappedThing;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,6 +219,9 @@ importers:
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
         version: 6.1.3(svelte@5.38.6)(vite@7.1.3(@types/node@24.3.0)(yaml@2.8.1))
+      schema-dts:
+        specifier: ^1.1.5
+        version: 1.1.5
       svelte:
         specifier: 'catalog:'
         version: 5.38.6

--- a/tests/svelte-5/package.json
+++ b/tests/svelte-5/package.json
@@ -14,6 +14,7 @@
     "@sveltejs/adapter-auto": "catalog:",
     "@sveltejs/kit": "catalog:",
     "@sveltejs/vite-plugin-svelte": "catalog:",
+    "schema-dts": "^1.1.5",
     "svelte": "catalog:",
     "svelte-check": "catalog:",
     "svelte-meta-tags": "workspace:*",

--- a/tests/svelte-5/src/routes/videoObjectType/+page.svelte
+++ b/tests/svelte-5/src/routes/videoObjectType/+page.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import type { WithContext, VideoObject } from 'schema-dts';
+  import { MetaTags, JsonLd } from 'svelte-meta-tags';
+
+  const jsonLdSchema: WithContext<VideoObject> = {
+    '@context': 'https://schema.org',
+    '@type': 'VideoObject',
+    name: 'Learn Svelte in 10 Minutes',
+    description:
+      'A comprehensive introduction to Svelte framework covering components, reactivity, and state management.',
+    contentUrl: 'https://example.com/videos/svelte-tutorial.mp4',
+    thumbnailUrl: 'https://example.com/thumbnails/svelte-tutorial.jpg',
+    uploadDate: '2024-01-15T10:00:00Z'
+  };
+</script>
+
+<MetaTags
+  title="VideoObject Type Test"
+  titleTemplate="%s | Svelte Meta Tags"
+  description="Testing VideoObject schema type with schema-dts"
+/>
+
+<JsonLd schema={jsonLdSchema} />
+
+<h1>VideoObject Type Test</h1>
+<p>This page tests the VideoObject schema type with schema-dts.</p>

--- a/tests/svelte-5/tests/videoObjectType.test.ts
+++ b/tests/svelte-5/tests/videoObjectType.test.ts
@@ -11,7 +11,9 @@ test('VideoObject type test page', async ({ page }) => {
   await expect(jsonLdScript).toBeAttached();
 
   const scriptContent = await jsonLdScript.textContent();
-  const jsonData = JSON.parse(scriptContent || '{}');
+  expect(scriptContent).not.toBeNull();
+  expect(scriptContent?.trim()).not.toBe('');
+  const jsonData = JSON.parse(scriptContent as string);
 
   expect(jsonData['@context']).toBe('https://schema.org');
   expect(jsonData['@type']).toBe('VideoObject');

--- a/tests/svelte-5/tests/videoObjectType.test.ts
+++ b/tests/svelte-5/tests/videoObjectType.test.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+
+test('VideoObject type test page', async ({ page }) => {
+  await page.goto('/videoObjectType');
+
+  await expect(page).toHaveTitle(/VideoObject Type Test/);
+
+  await expect(page.getByRole('heading', { name: 'VideoObject Type Test' })).toBeVisible();
+
+  const jsonLdScript = page.locator('script[type="application/ld+json"]');
+  await expect(jsonLdScript).toBeAttached();
+
+  const scriptContent = await jsonLdScript.textContent();
+  const jsonData = JSON.parse(scriptContent || '{}');
+
+  expect(jsonData['@context']).toBe('https://schema.org');
+  expect(jsonData['@type']).toBe('VideoObject');
+  expect(jsonData.name).toBe('Learn Svelte in 10 Minutes');
+  expect(jsonData.description).toBe(
+    'A comprehensive introduction to Svelte framework covering components, reactivity, and state management.'
+  );
+  expect(jsonData.contentUrl).toBe('https://example.com/videos/svelte-tutorial.mp4');
+  expect(jsonData.thumbnailUrl).toBe('https://example.com/thumbnails/svelte-tutorial.jpg');
+  expect(jsonData.uploadDate).toBe('2024-01-15T10:00:00Z');
+});


### PR DESCRIPTION
close: https://github.com/oekazuma/svelte-meta-tags/issues/1668

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved JSON-LD type compatibility so WithContext-based schema types (e.g., schema-dts VideoObject) can be passed directly, resolving previous TypeScript assignment issues.

- Tests
  - Added a SvelteKit demo page and Playwright test verifying VideoObject JSON-LD rendering and fields.
  - Added schema-dts as a dev dependency for test coverage.

- Documentation
  - Updated docs to reflect the broadened accepted shapes for JsonLdProps.schema.

- Chores
  - Added a patch changeset entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->