### PR TITLE
ci: parallelize jobs and unify tool versions across workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,26 +4,55 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '.changeset/**'
+      - '.vscode/**'
+      - '.husky/**'
   pull_request:
+    paths-ignore:
+      - '.changeset/**'
+      - '.vscode/**'
+      - '.husky/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  ci:
+  lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Install pnpm
-        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Setup Node.js and dependencies
+        uses: ./.github/workflows/setup-node
+      - name: Run Prettier check & ESLint
+        run: pnpm lint
+
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup Node.js and dependencies
+        uses: ./.github/workflows/setup-node
       - name: Run svelte-package
         run: pnpm package
       - name: Run svelte-check
         run: pnpm check
-      - name: Run ESLint
-        run: pnpm lint
+
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup Node.js and dependencies
+        uses: ./.github/workflows/setup-node
+      - name: Run svelte-package
+        run: pnpm package
       - name: Run Build
         run: pnpm build
-      - name: Install Playwright
-        run: pnpm dlx playwright@1.59.1 install --with-deps
+      - name: Setup Playwright
+        uses: ./.github/workflows/setup-playwright
       - name: Run Vitest and Playwright
         run: pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,15 +8,17 @@ on:
       - '.changeset/**'
       - '.vscode/**'
       - '.husky/**'
+      - '**/.github/**/*.md'
   pull_request:
     paths-ignore:
       - '.changeset/**'
       - '.vscode/**'
       - '.husky/**'
+      - '**/.github/**/*.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: true
 
 jobs:
   lint:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -18,12 +18,18 @@ jobs:
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Get Node.js version from .npmrc
+        id: get-node-version
+        run: echo "node-version=$(grep '^use-node-version=' .npmrc | cut -d'=' -f2)" >> "$GITHUB_OUTPUT"
+      - name: Get pnpm version from package.json
+        id: get-pnpm-version
+        run: echo "pnpm-version=$(node -p "require('./package.json').packageManager")" >> "$GITHUB_OUTPUT"
       - name: Install, build, and upload your site
         uses: withastro/action@b7d53628f8b666036b0238aadb0b984a2a489f26 # v6.1.1
         with:
           path: docs
-          node-version: 24.15.0
-          package-manager: pnpm@latest
+          node-version: ${{ steps.get-node-version.outputs.node-version }}
+          package-manager: ${{ steps.get-pnpm-version.outputs.pnpm-version }}
 
   deploy:
     needs: build

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -20,10 +20,22 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Get Node.js version from .npmrc
         id: get-node-version
-        run: echo "node-version=$(grep '^use-node-version=' .npmrc | cut -d'=' -f2)" >> "$GITHUB_OUTPUT"
+        run: |
+          NODE_VERSION=$(grep '^use-node-version=' .npmrc | cut -d'=' -f2 | tr -d '[:space:]')
+          if [ -z "$NODE_VERSION" ]; then
+            echo "::error::Could not extract use-node-version from .npmrc"
+            exit 1
+          fi
+          echo "node-version=${NODE_VERSION}" >> "$GITHUB_OUTPUT"
       - name: Get pnpm version from package.json
         id: get-pnpm-version
-        run: echo "pnpm-version=$(node -p "require('./package.json').packageManager")" >> "$GITHUB_OUTPUT"
+        run: |
+          PNPM_VERSION=$(node -p "require('./package.json').packageManager || ''")
+          if [ -z "$PNPM_VERSION" ] || [ "$PNPM_VERSION" = "undefined" ]; then
+            echo "::error::Missing packageManager in package.json"
+            exit 1
+          fi
+          echo "pnpm-version=${PNPM_VERSION}" >> "$GITHUB_OUTPUT"
       - name: Install, build, and upload your site
         uses: withastro/action@b7d53628f8b666036b0238aadb0b984a2a489f26 # v6.1.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,12 +17,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
-      - run: pnpm install --frozen-lockfile
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - name: Setup Node.js and dependencies
+        uses: ./.github/workflows/setup-node
         with:
-          node-version: '24.15.0'
           registry-url: 'https://registry.npmjs.org'
       - name: Create Release Pull Request or Publish to npm
         id: changesets

--- a/.github/workflows/setup-node/action.yml
+++ b/.github/workflows/setup-node/action.yml
@@ -1,0 +1,30 @@
+name: 'Setup Node.js and pnpm'
+description: 'Install pnpm, set up Node.js using version from .npmrc, and install dependencies'
+
+inputs:
+  registry-url:
+    description: 'Optional npm registry URL for publishing'
+    required: false
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Get Node.js version from .npmrc
+      id: get-node-version
+      shell: bash
+      run: echo "node-version=$(grep '^use-node-version=' .npmrc | cut -d'=' -f2)" >> "$GITHUB_OUTPUT"
+
+    - name: Install pnpm
+      uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
+
+    - name: Setup Node.js
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+        node-version: ${{ steps.get-node-version.outputs.node-version }}
+        cache: 'pnpm'
+        registry-url: ${{ inputs.registry-url }}
+
+    - name: Install dependencies
+      shell: bash
+      run: pnpm install --frozen-lockfile

--- a/.github/workflows/setup-node/action.yml
+++ b/.github/workflows/setup-node/action.yml
@@ -13,7 +13,13 @@ runs:
     - name: Get Node.js version from .npmrc
       id: get-node-version
       shell: bash
-      run: echo "node-version=$(grep '^use-node-version=' .npmrc | cut -d'=' -f2)" >> "$GITHUB_OUTPUT"
+      run: |
+        NODE_VERSION=$(grep '^use-node-version=' .npmrc | cut -d'=' -f2 | tr -d '[:space:]')
+        if [ -z "$NODE_VERSION" ]; then
+          echo "::error::Could not extract use-node-version from .npmrc"
+          exit 1
+        fi
+        echo "node-version=${NODE_VERSION}" >> "$GITHUB_OUTPUT"
 
     - name: Install pnpm
       uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5

--- a/.github/workflows/setup-playwright/action.yml
+++ b/.github/workflows/setup-playwright/action.yml
@@ -21,3 +21,8 @@ runs:
       if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
       shell: bash
       run: pnpm --filter svelte-5 exec playwright install --with-deps
+
+    - name: Install Playwright system dependencies
+      if: steps.cache-playwright-browsers.outputs.cache-hit == 'true'
+      shell: bash
+      run: pnpm --filter svelte-5 exec playwright install-deps

--- a/.github/workflows/setup-playwright/action.yml
+++ b/.github/workflows/setup-playwright/action.yml
@@ -1,0 +1,23 @@
+name: 'Setup Playwright'
+description: 'Cache and install Playwright browsers using the version from pnpm-workspace.yaml'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Get Playwright version from pnpm-workspace.yaml
+      shell: bash
+      run: echo "PLAYWRIGHT_VERSION=$(grep '@playwright/test' pnpm-workspace.yaml | awk '{print $2}' | sed 's/\^//')" >> "${GITHUB_ENV}"
+
+    - name: Cache Playwright browsers
+      id: cache-playwright-browsers
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+        restore-keys: |
+          ${{ runner.os }}-playwright-
+
+    - name: Install Playwright browsers
+      if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
+      shell: bash
+      run: pnpm --filter svelte-5 exec playwright install --with-deps


### PR DESCRIPTION
## Summary

- Split the single sequential CI job into parallel `lint` / `check` / `test` jobs and added `concurrency`, `paths-ignore`, and per-job `timeout-minutes`
- Extracted shared setup steps into composite actions (`.github/workflows/setup-node`, `.github/workflows/setup-playwright`) and reused them from `ci.yml` and `release.yml`
- Unified the single source of truth for each tool version:
  - **Node.js** → `.npmrc` (`use-node-version`)
  - **pnpm** → `package.json` (`packageManager`)
  - **Playwright** → `pnpm-workspace.yaml` catalog (`@playwright/test`)
- Cache Playwright browser binaries with cache key `${runner.os}-playwright-${PLAYWRIGHT_VERSION}`

## Test plan

- [ ] `lint` / `check` / `test` jobs all pass in parallel
- [ ] Older runs are cancelled when new commits are pushed to the same PR
- [ ] CI is skipped for changes limited to `.changeset/**`
- [ ] Playwright browser cache hits and misses behave as expected
- [ ] `release.yml` continues to succeed on merges to `main`
- [ ] `deploy-docs.yml` continues to succeed on `docs/**` changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI revamped: split into lint, package/check, and test jobs with concurrency and cancel-in-progress; runs on push and pull requests and skips irrelevant config paths.
  * Release/deploy workflows now derive Node and package-manager versions from project config instead of hardcoding.
  * Common node/dependency setup consolidated into reusable workflow steps.

* **New Features**
  * Playwright setup adds version-aware caching of browser binaries and conditional install behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->