### PR TITLE
chore: add npm bugs metadata to package.json

### DIFF
--- a/packages/svelte-meta-tags/package.json
+++ b/packages/svelte-meta-tags/package.json
@@ -66,5 +66,8 @@
     "dist"
   ],
   "svelte": "./dist/index.js",
-  "types": "./dist/index.d.ts"
+  "types": "./dist/index.d.ts",
+  "bugs": {
+    "url": "https://github.com/oekazuma/svelte-meta-tags/issues"
+  }
 }


### PR DESCRIPTION
## Problem

`svelte-meta-tags@5.0.0` exposes `repository` and `homepage` metadata but not `bugs`.

```sh
npm view svelte-meta-tags bugs
# (empty)
```

## Fix

Add `bugs.url` pointing to the GitHub issue tracker:

```json
"bugs": { "url": "https://github.com/oekazuma/svelte-meta-tags/issues" }
```

Metadata-only change — no runtime behaviour is affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added bug reporting metadata to package configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->