### PR TITLE
test: fix flaky webkit e2e by using waitUntil domcontentloaded

### DIFF
--- a/tests/svelte-5/tests/additionalRobots.test.ts
+++ b/tests/svelte-5/tests/additionalRobots.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 test('Additional Robots props SEO applied correctly', async ({ page }) => {
-  await page.goto('/additionalRobots');
+  await page.goto('/additionalRobots', { waitUntil: 'domcontentloaded' });
   await expect(page).toHaveTitle('Additional Robots meta title | Svelte Meta Tags');
   await expect(page.locator('h1')).toContainText('Robots props SEO');
   await expect(page.locator('head meta[name="robots"]')).toHaveAttribute(

--- a/tests/svelte-5/tests/another.test.ts
+++ b/tests/svelte-5/tests/another.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 test('Another pattern SEO loads correctly', async ({ page }) => {
-  await page.goto('/another');
+  await page.goto('/another', { waitUntil: 'domcontentloaded' });
   await expect(page).toHaveTitle('');
   await expect(page.locator('h1')).toContainText('Another SEO');
   await expect(page.locator('head meta[name="description"]')).toHaveAttribute('content', 'Description Another');

--- a/tests/svelte-5/tests/article.test.ts
+++ b/tests/svelte-5/tests/article.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 test('Article SEO loads correctly', async ({ page }) => {
-  await page.goto('/article');
+  await page.goto('/article', { waitUntil: 'domcontentloaded' });
   await expect(page).toHaveTitle('Article Page Title | Svelte Meta Tags');
   await expect(page.locator('h1')).toContainText('Article SEO');
   await expect(page.locator('head meta[name="description"]')).toHaveAttribute('content', 'Description of article page');

--- a/tests/svelte-5/tests/book.test.ts
+++ b/tests/svelte-5/tests/book.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 test('Book SEO loads correctly', async ({ page }) => {
-  await page.goto('/book');
+  await page.goto('/book', { waitUntil: 'domcontentloaded' });
   await expect(page).toHaveTitle('Book Page Title | Svelte Meta Tags');
   await expect(page.locator('h1')).toContainText('Book SEO');
   await expect(page.locator('head meta[name="description"]')).toHaveAttribute('content', 'Description of book page');

--- a/tests/svelte-5/tests/jsonLdArray.test.ts
+++ b/tests/svelte-5/tests/jsonLdArray.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 test('JSON-LD Array SEO loads correctly', async ({ page }) => {
-  await page.goto('/jsonldArray');
+  await page.goto('/jsonldArray', { waitUntil: 'domcontentloaded' });
   await expect(page).toHaveTitle('JSON-LD Array Page Title | Svelte Meta Tags');
   await expect(page.locator('h1')).toContainText('JSON-LD Array SEO');
   await expect(page.locator('head meta[name="description"]')).toHaveAttribute(

--- a/tests/svelte-5/tests/jsonLdBody.test.ts
+++ b/tests/svelte-5/tests/jsonLdBody.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 test('JSON-LD Head SEO loads correctly', async ({ page }) => {
-  await page.goto('/jsonldBody');
+  await page.goto('/jsonldBody', { waitUntil: 'domcontentloaded' });
   await expect(page).toHaveTitle('JSON-LD Body Page Title | Svelte Meta Tags');
   await expect(page.locator('h1')).toContainText('JSON-LD Body SEO');
   await expect(page.locator('head meta[name="description"]')).toHaveAttribute(

--- a/tests/svelte-5/tests/jsonLdGraph.test.ts
+++ b/tests/svelte-5/tests/jsonLdGraph.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 test('JSON-LD Graph SEO loads correctly', async ({ page }) => {
-  await page.goto('/jsonldGraph');
+  await page.goto('/jsonldGraph', { waitUntil: 'domcontentloaded' });
   await expect(page).toHaveTitle('JSON-LD Graph Page Title | Svelte Meta Tags');
   await expect(page.locator('h1')).toContainText('JSON-LD Graph SEO');
   await expect(page.locator('head meta[name="description"]')).toHaveAttribute(

--- a/tests/svelte-5/tests/jsonLdHead.test.ts
+++ b/tests/svelte-5/tests/jsonLdHead.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 test('JSON-LD Head SEO loads correctly', async ({ page }) => {
-  await page.goto('/jsonldHead');
+  await page.goto('/jsonldHead', { waitUntil: 'domcontentloaded' });
   await expect(page).toHaveTitle('JSON-LD Head Page Title | Svelte Meta Tags');
   await expect(page.locator('h1')).toContainText('JSON-LD Head SEO');
   await expect(page.locator('head meta[name="description"]')).toHaveAttribute(

--- a/tests/svelte-5/tests/normal.test.ts
+++ b/tests/svelte-5/tests/normal.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 test('Normal SEO loads correctly', async ({ page, baseURL }) => {
-  await page.goto('/');
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
   await expect(page).toHaveTitle('Normal | Svelte Meta Tags');
   await expect(page.locator('h1')).toContainText('Normal SEO');
   await expect(page.locator('head meta[name="description"]')).toHaveAttribute('content', 'Description');

--- a/tests/svelte-5/tests/openGraphImage.test.ts
+++ b/tests/svelte-5/tests/openGraphImage.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 test('openGraph.image is rendered as the first og:image and prepended to openGraph.images', async ({ page }) => {
-  await page.goto('/openGraphImage');
+  await page.goto('/openGraphImage', { waitUntil: 'domcontentloaded' });
 
   const ogImage = page.locator('head meta[property="og:image"]');
   await expect(ogImage).toHaveCount(2);

--- a/tests/svelte-5/tests/profile.test.ts
+++ b/tests/svelte-5/tests/profile.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 test('Profile SEO loads correctly', async ({ page }) => {
-  await page.goto('/profile');
+  await page.goto('/profile', { waitUntil: 'domcontentloaded' });
   await expect(page).toHaveTitle('Profile Page Title | Svelte Meta Tags');
   await expect(page.locator('h1')).toContainText('Profile SEO');
   await expect(page.locator('head meta[name="description"]')).toHaveAttribute('content', 'Description of profile page');

--- a/tests/svelte-5/tests/robots.test.ts
+++ b/tests/svelte-5/tests/robots.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 test('Robots props SEO applied correctly', async ({ page }) => {
-  await page.goto('/robots');
+  await page.goto('/robots', { waitUntil: 'domcontentloaded' });
   await expect(page).toHaveTitle('Robots meta title | Svelte Meta Tags');
   await expect(page.locator('h1')).toContainText('Robots props SEO');
   await expect(page.locator('head meta[name="robots"]')).toHaveAttribute('content', 'noindex,nofollow');

--- a/tests/svelte-5/tests/robotsAnother.test.ts
+++ b/tests/svelte-5/tests/robotsAnother.test.ts
@@ -17,7 +17,7 @@ test('Another Robots props SEO applied correctly', async ({ page }) => {
     });
   });
 
-  await page.goto('/robots/another');
+  await page.goto('/robots/another', { waitUntil: 'domcontentloaded' });
   await expect(page).toHaveTitle('Another Robots meta title | Svelte Meta Tags');
   await expect(page.locator('h1')).toContainText('Another Robots props SEO');
   await expect(page.locator('head meta[name="robots"]')).toHaveCount(0);

--- a/tests/svelte-5/tests/robotsGooglebot.test.ts
+++ b/tests/svelte-5/tests/robotsGooglebot.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 test('Googlebot Robots props SEO applied correctly', async ({ page }) => {
-  await page.goto('/robots/googlebot');
+  await page.goto('/robots/googlebot', { waitUntil: 'domcontentloaded' });
   await expect(page).toHaveTitle('Googlebot Robots meta title | Svelte Meta Tags');
   await expect(page.locator('h1')).toContainText('Googlebot Robots props SEO');
   await expect(page.locator('head meta[name="robots"]')).toHaveCount(0);

--- a/tests/svelte-5/tests/searchAction.test.ts
+++ b/tests/svelte-5/tests/searchAction.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 test('SearchAction with query-input loads correctly', async ({ page }) => {
-  await page.goto('/searchAction');
+  await page.goto('/searchAction', { waitUntil: 'domcontentloaded' });
   await expect(page).toHaveTitle('SearchAction Test | Svelte Meta Tags');
   await expect(page.locator('h1')).toContainText('SearchAction Test');
   await expect(page.locator('head meta[name="description"]')).toHaveAttribute(

--- a/tests/svelte-5/tests/searchActionType.test.ts
+++ b/tests/svelte-5/tests/searchActionType.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 test('SearchAction type test page', async ({ page }) => {
-  await page.goto('/searchActionType');
+  await page.goto('/searchActionType', { waitUntil: 'domcontentloaded' });
 
   await expect(page).toHaveTitle(/SearchAction Type Test/);
 

--- a/tests/svelte-5/tests/twitter.test.ts
+++ b/tests/svelte-5/tests/twitter.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 test('MetaTags component renders correct meta tags for Twitter', async ({ page }) => {
-  await page.goto('/twitter');
+  await page.goto('/twitter', { waitUntil: 'domcontentloaded' });
   await expect(page.locator('head meta[name="twitter:card"]')).toHaveAttribute('content', 'summary_large_image');
   await expect(page.locator('head meta[name="twitter:site"]')).toHaveAttribute('content', '@site');
   await expect(page.locator('head meta[name="twitter:description"]')).toHaveAttribute('content', 'twitter test');

--- a/tests/svelte-5/tests/twitterFallback.test.ts
+++ b/tests/svelte-5/tests/twitterFallback.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 test('Twitter metadata falls back to OpenGraph values when not explicitly set', async ({ page }) => {
-  await page.goto('/twitterFallback');
+  await page.goto('/twitterFallback', { waitUntil: 'domcontentloaded' });
   await expect(page.locator('head meta[name="twitter:card"]')).toHaveAttribute('content', 'summary_large_image');
   await expect(page.locator('head meta[name="twitter:site"]')).toHaveAttribute('content', '@site');
   await expect(page.locator('head meta[name="twitter:title"]')).toHaveAttribute('content', 'OG Title');
@@ -9,25 +9,25 @@ test('Twitter metadata falls back to OpenGraph values when not explicitly set', 
 });
 
 test('Twitter metadata falls back to standard meta values when OG is also not set', async ({ page }) => {
-  await page.goto('/twitterFallbackTitle');
+  await page.goto('/twitterFallbackTitle', { waitUntil: 'domcontentloaded' });
   await expect(page.locator('head meta[name="twitter:title"]')).toHaveAttribute('content', 'Page Title');
   await expect(page.locator('head meta[name="twitter:description"]')).toHaveAttribute('content', 'Page Description');
 });
 
 test('Twitter metadata uses explicit values over fallbacks', async ({ page }) => {
-  await page.goto('/twitterFallbackExplicit');
+  await page.goto('/twitterFallbackExplicit', { waitUntil: 'domcontentloaded' });
   await expect(page.locator('head meta[name="twitter:title"]')).toHaveAttribute('content', 'Twitter Title');
   await expect(page.locator('head meta[name="twitter:description"]')).toHaveAttribute('content', 'Twitter Description');
 });
 
 test('Twitter metadata falls back independently per field (mixed fallback)', async ({ page }) => {
-  await page.goto('/twitterFallbackMixed');
+  await page.goto('/twitterFallbackMixed', { waitUntil: 'domcontentloaded' });
   await expect(page.locator('head meta[name="twitter:title"]')).toHaveAttribute('content', 'OG Title');
   await expect(page.locator('head meta[name="twitter:description"]')).toHaveAttribute('content', 'Page Description');
 });
 
 test('Twitter title fallback uses titleTemplate-applied title', async ({ page }) => {
-  await page.goto('/twitterFallbackTemplate');
+  await page.goto('/twitterFallbackTemplate', { waitUntil: 'domcontentloaded' });
   await expect(page.locator('head meta[name="twitter:title"]')).toHaveAttribute('content', 'Home | MySite');
   await expect(page.locator('head meta[name="twitter:description"]')).toHaveAttribute('content', 'Page Description');
 });

--- a/tests/svelte-5/tests/video.test.ts
+++ b/tests/svelte-5/tests/video.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 test('Video SEO loads correctly', async ({ page }) => {
-  await page.goto('/video');
+  await page.goto('/video', { waitUntil: 'domcontentloaded' });
   await expect(page).toHaveTitle('Video Page Title | Svelte Meta Tags');
   await expect(page.locator('h1')).toContainText('Video SEO');
   await expect(page.locator('head meta[name="description"]')).toHaveAttribute('content', 'Description of video page');

--- a/tests/svelte-5/tests/videoObjectType.test.ts
+++ b/tests/svelte-5/tests/videoObjectType.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 test('VideoObject type test page', async ({ page }) => {
-  await page.goto('/videoObjectType');
+  await page.goto('/videoObjectType', { waitUntil: 'domcontentloaded' });
 
   await expect(page).toHaveTitle(/VideoObject Type Test/);
 


### PR DESCRIPTION
## Background

The CI `test` job (webkit) was failing intermittently ([the run](https://github.com/oekazuma/svelte-meta-tags/actions/runs/27926488114/job/82631526090)). Tests pass locally but are flaky on CI.

## Root cause

The only failure was webkit's `Normal SEO loads correctly`, where `page.goto('/')` **timed out at 45s and exhausted all 5 retries** — it never reached the test assertions.

- The `/` route (root `+page.svelte`) renders the **most external-host link tags** of any test route: `apple-touch-icon` ×2 / `mask-icon` / `manifest`, all pointing to `https://www.test.ie/...` (unreachable from CI).
- `page.goto` defaults to `waitUntil: 'load'`. WebKit is stricter than other browsers about fetching these external icons/manifest, so when the connection hangs on CI the `load` lifecycle never settles and times out. When the connection fails fast it passes, which is why it's **flaky**. This matches the observation that other routes with fewer external links pass on webkit.

## Changes

Switched every e2e `page.goto(...)` to `{ waitUntil: 'domcontentloaded' }` (20 files / 24 call sites).

```diff
-  await page.goto('/');
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
```

Every test only asserts on `<head>` meta/link tags and `h1` text, all of which are present at DOMContentLoaded thanks to SSR. Waiting for `load` (i.e. external subresources) is unnecessary, and dropping it removes the dependency on external hosts, eliminating the hang at its root.

## Notes

- No changeset needed since this is a tests-only change (per `AGENTS.md`).
- Verified passing locally on both webkit and chromium.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test navigation timing across 21 test suites to ensure pages fully load before running assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->