### PR TITLE
ci: use `node --run` instead of `pnpm` for running scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Node.js and dependencies
         uses: ./.github/workflows/setup-node
       - name: Run Prettier check & ESLint
-        run: pnpm lint
+        run: node --run lint
 
   check:
     runs-on: ubuntu-latest
@@ -42,9 +42,9 @@ jobs:
       - name: Setup Node.js and dependencies
         uses: ./.github/workflows/setup-node
       - name: Run svelte-package
-        run: pnpm package
+        run: node --run package
       - name: Run svelte-check
-        run: pnpm check
+        run: node --run check
 
   test:
     runs-on: ubuntu-latest
@@ -54,10 +54,10 @@ jobs:
       - name: Setup Node.js and dependencies
         uses: ./.github/workflows/setup-node
       - name: Run svelte-package
-        run: pnpm package
+        run: node --run package
       - name: Run Build
-        run: pnpm build
+        run: node --run build
       - name: Setup Playwright
         uses: ./.github/workflows/setup-playwright
       - name: Run Vitest and Playwright
-        run: pnpm test
+        run: node --run test


### PR DESCRIPTION
## Summary

Replace top-level `pnpm <script>` invocations with `node --run <script>` in the CI workflow. `node --run` skips the package-manager startup overhead when running `package.json` scripts, so each CI step starts a little faster.

Affected steps in `.github/workflows/ci.yml`:

- `pnpm lint` → `node --run lint`
- `pnpm package` → `node --run package`
- `pnpm check` → `node --run check`
- `pnpm build` → `node --run build`
- `pnpm test` → `node --run test`

## Notes

- `node --run` is stable since Node 22; this repo pins Node 24.15.0 via `devEngines.runtime`, so it is available.
- Scripts whose body uses `pnpm -r` (`package`, `build`, `check`, `test`) still invoke pnpm internally — only the top-level entrypoint changes.
- No `pre`/`post` scripts exist, so `node --run` not running them has no effect here.
- `pnpm --filter ...` / `pnpm install` calls in the composite actions are pnpm CLI commands (not script runs) and are intentionally left unchanged.
- Internal-only change (CI), so no changeset is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated checks to run linting, packaging, build, and test steps through the standard project script runner.
  * Improved CI step clarity by splitting some checks into separate stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->