### PR TITLE
fix(refactor): clean up `MetaTags.svelte` conditionals and each blocks

### DIFF
--- a/.changeset/clean-metatags-conditionals.md
+++ b/.changeset/clean-metatags-conditionals.md
@@ -1,0 +1,5 @@
+---
+'svelte-meta-tags': patch
+---
+
+refactor: clean up conditionals and each blocks in `MetaTags.svelte`

--- a/packages/svelte-meta-tags/src/lib/MetaTags.svelte
+++ b/packages/svelte-meta-tags/src/lib/MetaTags.svelte
@@ -254,7 +254,7 @@
     {/if}
 
     {#if openGraph.image || openGraph.images?.length}
-      {const ogImages = openGraph.image ? [openGraph.image, ...(openGraph.images || [])] : openGraph.images}
+      {@const ogImages = openGraph.image ? [openGraph.image, ...(openGraph.images || [])] : openGraph.images}
       {#each ogImages as image (image)}
         <meta property="og:image" content={image.url} />
         {#if image.alt}

--- a/packages/svelte-meta-tags/src/lib/MetaTags.svelte
+++ b/packages/svelte-meta-tags/src/lib/MetaTags.svelte
@@ -253,7 +253,7 @@
       <meta property="og:description" content={openGraph.description || description} />
     {/if}
 
-    {#if openGraph.image || (openGraph.images && openGraph.images.length)}
+    {#if openGraph.image || openGraph.images?.length}
       {@const ogImages = openGraph.image ? [openGraph.image, ...(openGraph.images || [])] : openGraph.images}
       {#each ogImages as image (image)}
         <meta property="og:image" content={image.url} />

--- a/packages/svelte-meta-tags/src/lib/MetaTags.svelte
+++ b/packages/svelte-meta-tags/src/lib/MetaTags.svelte
@@ -254,7 +254,7 @@
     {/if}
 
     {#if openGraph.image || openGraph.images?.length}
-      {@const ogImages = openGraph.image ? [openGraph.image, ...(openGraph.images || [])] : openGraph.images}
+      {const ogImages = openGraph.image ? [openGraph.image, ...(openGraph.images || [])] : openGraph.images}
       {#each ogImages as image (image)}
         <meta property="og:image" content={image.url} />
         {#if image.alt}

--- a/packages/svelte-meta-tags/src/lib/MetaTags.svelte
+++ b/packages/svelte-meta-tags/src/lib/MetaTags.svelte
@@ -18,7 +18,7 @@
     additionalLinkTags = undefined
   }: Partial<MetaTagsProps> = $props();
 
-  let updatedTitle = $derived(titleTemplate ? (title ? titleTemplate.replace(/%s/g, title) : title) : title);
+  let updatedTitle = $derived(title && (titleTemplate?.replace(/%s/g, title) ?? title));
 
   let robotsParams = $derived.by(() => {
     if (!additionalRobotsProps) return '';
@@ -72,9 +72,9 @@
     <link rel="alternate" media={mobileAlternate.media} href={mobileAlternate.href} />
   {/if}
 
-    {#each languageAlternates as languageAlternate (languageAlternate)}
-      <link rel="alternate" hrefLang={languageAlternate.hrefLang} href={languageAlternate.href} />
-    {/each}
+  {#each languageAlternates as languageAlternate (languageAlternate)}
+    <link rel="alternate" hrefLang={languageAlternate.hrefLang} href={languageAlternate.href} />
+  {/each}
 
   {#if twitter}
     {#if twitter.cardType}
@@ -171,8 +171,8 @@
         {/if}
       {:else if openGraph.type.toLowerCase() === 'book' && openGraph.book}
         {#each openGraph.book?.authors as author (author)}
-            <meta property="book:author" content={author} />
-          {/each}
+          <meta property="book:author" content={author} />
+        {/each}
 
         {#if openGraph.book.isbn}
           <meta property="book:isbn" content={openGraph.book.isbn} />
@@ -183,8 +183,8 @@
         {/if}
 
         {#each openGraph.book?.tags as tag (tag)}
-            <meta property="book:tag" content={tag} />
-          {/each}
+          <meta property="book:tag" content={tag} />
+        {/each}
       {:else if openGraph.type.toLowerCase() === 'article' && openGraph.article}
         {#if openGraph.article.publishedTime}
           <meta property="article:published_time" content={openGraph.article.publishedTime} />
@@ -199,33 +199,33 @@
         {/if}
 
         {#each openGraph.article?.authors as author (author)}
-            <meta property="article:author" content={author} />
-          {/each}
+          <meta property="article:author" content={author} />
+        {/each}
 
         {#if openGraph.article.section}
           <meta property="article:section" content={openGraph.article.section} />
         {/if}
 
         {#each openGraph.article?.tags as tag (tag)}
-            <meta property="article:tag" content={tag} />
-          {/each}
+          <meta property="article:tag" content={tag} />
+        {/each}
       {:else if openGraph.type.toLowerCase() === 'video.movie' || openGraph.type.toLowerCase() === 'video.episode' || openGraph.type.toLowerCase() === 'video.tv_show' || (openGraph.type.toLowerCase() === 'video.other' && openGraph.video)}
         {#each openGraph.video?.actors as actor (actor)}
-            {#if actor.profile}
-              <meta property="video:actor" content={actor.profile} />
-            {/if}
-            {#if actor.role}
-              <meta property="video:actor:role" content={actor.role} />
-            {/if}
-          {/each}
+          {#if actor.profile}
+            <meta property="video:actor" content={actor.profile} />
+          {/if}
+          {#if actor.role}
+            <meta property="video:actor:role" content={actor.role} />
+          {/if}
+        {/each}
 
         {#each openGraph.video?.directors as director (director)}
-            <meta property="video:director" content={director} />
-          {/each}
+          <meta property="video:director" content={director} />
+        {/each}
 
         {#each openGraph.video?.writers as writer (writer)}
-            <meta property="video:writer" content={writer} />
-          {/each}
+          <meta property="video:writer" content={writer} />
+        {/each}
 
         {#if openGraph.video?.duration}
           <meta property="video:duration" content={openGraph.video.duration.toString()} />
@@ -236,8 +236,8 @@
         {/if}
 
         {#each openGraph.video?.tags as tag (tag)}
-            <meta property="video:tag" content={tag} />
-          {/each}
+          <meta property="video:tag" content={tag} />
+        {/each}
 
         {#if openGraph.video?.series}
           <meta property="video:series" content={openGraph.video.series} />
@@ -275,31 +275,31 @@
       {/each}
     {/if}
 
-      {#each openGraph.videos as video (video)}
-        <meta property="og:video" content={video.url} />
-        {#if video.width}
-          <meta property="og:video:width" content={video.width.toString()} />
-        {/if}
-        {#if video.height}
-          <meta property="og:video:height" content={video.height.toString()} />
-        {/if}
-        {#if video.secureUrl}
-          <meta property="og:video:secure_url" content={video.secureUrl.toString()} />
-        {/if}
-        {#if video.type}
-          <meta property="og:video:type" content={video.type.toString()} />
-        {/if}
-      {/each}
+    {#each openGraph.videos as video (video)}
+      <meta property="og:video" content={video.url} />
+      {#if video.width}
+        <meta property="og:video:width" content={video.width.toString()} />
+      {/if}
+      {#if video.height}
+        <meta property="og:video:height" content={video.height.toString()} />
+      {/if}
+      {#if video.secureUrl}
+        <meta property="og:video:secure_url" content={video.secureUrl.toString()} />
+      {/if}
+      {#if video.type}
+        <meta property="og:video:type" content={video.type.toString()} />
+      {/if}
+    {/each}
 
-      {#each openGraph.audio as audio (audio)}
-        <meta property="og:audio" content={audio.url} />
-        {#if audio.secureUrl}
-          <meta property="og:audio:secure_url" content={audio.secureUrl.toString()} />
-        {/if}
-        {#if audio.type}
-          <meta property="og:audio:type" content={audio.type.toString()} />
-        {/if}
-      {/each}
+    {#each openGraph.audio as audio (audio)}
+      <meta property="og:audio" content={audio.url} />
+      {#if audio.secureUrl}
+        <meta property="og:audio:secure_url" content={audio.secureUrl.toString()} />
+      {/if}
+      {#if audio.type}
+        <meta property="og:audio:type" content={audio.type.toString()} />
+      {/if}
+    {/each}
 
     {#if openGraph.locale}
       <meta property="og:locale" content={openGraph.locale} />
@@ -310,11 +310,11 @@
     {/if}
   {/if}
 
-    {#each additionalMetaTags as tag (tag)}
-      <meta {...tag.httpEquiv ? { ...tag, 'http-equiv': tag.httpEquiv } : tag} />
-    {/each}
+  {#each additionalMetaTags as tag (tag)}
+    <meta {...tag.httpEquiv ? { ...tag, 'http-equiv': tag.httpEquiv } : tag} />
+  {/each}
 
-    {#each additionalLinkTags as tag (tag)}
-      <link {...tag} />
-    {/each}
+  {#each additionalLinkTags as tag (tag)}
+    <link {...tag} />
+  {/each}
 </svelte:head>

--- a/packages/svelte-meta-tags/src/lib/MetaTags.svelte
+++ b/packages/svelte-meta-tags/src/lib/MetaTags.svelte
@@ -72,11 +72,9 @@
     <link rel="alternate" media={mobileAlternate.media} href={mobileAlternate.href} />
   {/if}
 
-  {#if languageAlternates && languageAlternates.length > 0}
     {#each languageAlternates as languageAlternate (languageAlternate)}
       <link rel="alternate" hrefLang={languageAlternate.hrefLang} href={languageAlternate.href} />
     {/each}
-  {/if}
 
   {#if twitter}
     {#if twitter.cardType}
@@ -172,11 +170,9 @@
           <meta property="profile:gender" content={openGraph.profile.gender} />
         {/if}
       {:else if openGraph.type.toLowerCase() === 'book' && openGraph.book}
-        {#if openGraph.book.authors && openGraph.book.authors.length}
-          {#each openGraph.book.authors as author (author)}
+        {#each openGraph.book?.authors as author (author)}
             <meta property="book:author" content={author} />
           {/each}
-        {/if}
 
         {#if openGraph.book.isbn}
           <meta property="book:isbn" content={openGraph.book.isbn} />
@@ -186,11 +182,9 @@
           <meta property="book:release_date" content={openGraph.book.releaseDate} />
         {/if}
 
-        {#if openGraph.book.tags && openGraph.book.tags.length}
-          {#each openGraph.book.tags as tag (tag)}
+        {#each openGraph.book?.tags as tag (tag)}
             <meta property="book:tag" content={tag} />
           {/each}
-        {/if}
       {:else if openGraph.type.toLowerCase() === 'article' && openGraph.article}
         {#if openGraph.article.publishedTime}
           <meta property="article:published_time" content={openGraph.article.publishedTime} />
@@ -204,24 +198,19 @@
           <meta property="article:expiration_time" content={openGraph.article.expirationTime} />
         {/if}
 
-        {#if openGraph.article.authors && openGraph.article.authors.length}
-          {#each openGraph.article.authors as author (author)}
+        {#each openGraph.article?.authors as author (author)}
             <meta property="article:author" content={author} />
           {/each}
-        {/if}
 
         {#if openGraph.article.section}
           <meta property="article:section" content={openGraph.article.section} />
         {/if}
 
-        {#if openGraph.article.tags && openGraph.article.tags.length}
-          {#each openGraph.article.tags as tag (tag)}
+        {#each openGraph.article?.tags as tag (tag)}
             <meta property="article:tag" content={tag} />
           {/each}
-        {/if}
       {:else if openGraph.type.toLowerCase() === 'video.movie' || openGraph.type.toLowerCase() === 'video.episode' || openGraph.type.toLowerCase() === 'video.tv_show' || (openGraph.type.toLowerCase() === 'video.other' && openGraph.video)}
-        {#if openGraph.video?.actors && openGraph.video.actors.length}
-          {#each openGraph.video.actors as actor (actor)}
+        {#each openGraph.video?.actors as actor (actor)}
             {#if actor.profile}
               <meta property="video:actor" content={actor.profile} />
             {/if}
@@ -229,19 +218,14 @@
               <meta property="video:actor:role" content={actor.role} />
             {/if}
           {/each}
-        {/if}
 
-        {#if openGraph.video?.directors && openGraph.video.directors.length}
-          {#each openGraph.video.directors as director (director)}
+        {#each openGraph.video?.directors as director (director)}
             <meta property="video:director" content={director} />
           {/each}
-        {/if}
 
-        {#if openGraph.video?.writers && openGraph.video.writers.length}
-          {#each openGraph.video.writers as writer (writer)}
+        {#each openGraph.video?.writers as writer (writer)}
             <meta property="video:writer" content={writer} />
           {/each}
-        {/if}
 
         {#if openGraph.video?.duration}
           <meta property="video:duration" content={openGraph.video.duration.toString()} />
@@ -251,11 +235,9 @@
           <meta property="video:release_date" content={openGraph.video.releaseDate} />
         {/if}
 
-        {#if openGraph.video?.tags && openGraph.video.tags.length}
-          {#each openGraph.video.tags as tag (tag)}
+        {#each openGraph.video?.tags as tag (tag)}
             <meta property="video:tag" content={tag} />
           {/each}
-        {/if}
 
         {#if openGraph.video?.series}
           <meta property="video:series" content={openGraph.video.series} />
@@ -293,7 +275,6 @@
       {/each}
     {/if}
 
-    {#if openGraph.videos && openGraph.videos.length}
       {#each openGraph.videos as video (video)}
         <meta property="og:video" content={video.url} />
         {#if video.width}
@@ -309,9 +290,7 @@
           <meta property="og:video:type" content={video.type.toString()} />
         {/if}
       {/each}
-    {/if}
 
-    {#if openGraph.audio && openGraph.audio.length}
       {#each openGraph.audio as audio (audio)}
         <meta property="og:audio" content={audio.url} />
         {#if audio.secureUrl}
@@ -321,7 +300,6 @@
           <meta property="og:audio:type" content={audio.type.toString()} />
         {/if}
       {/each}
-    {/if}
 
     {#if openGraph.locale}
       <meta property="og:locale" content={openGraph.locale} />
@@ -332,15 +310,11 @@
     {/if}
   {/if}
 
-  {#if additionalMetaTags && Array.isArray(additionalMetaTags)}
     {#each additionalMetaTags as tag (tag)}
       <meta {...tag.httpEquiv ? { ...tag, 'http-equiv': tag.httpEquiv } : tag} />
     {/each}
-  {/if}
 
-  {#if additionalLinkTags?.length}
     {#each additionalLinkTags as tag (tag)}
       <link {...tag} />
     {/each}
-  {/if}
 </svelte:head>

--- a/packages/svelte-meta-tags/src/lib/MetaTags.svelte
+++ b/packages/svelte-meta-tags/src/lib/MetaTags.svelte
@@ -209,7 +209,7 @@
         {#each openGraph.article?.tags as tag (tag)}
           <meta property="article:tag" content={tag} />
         {/each}
-      {:else if openGraph.type.toLowerCase() === 'video.movie' || openGraph.type.toLowerCase() === 'video.episode' || openGraph.type.toLowerCase() === 'video.tv_show' || (openGraph.type.toLowerCase() === 'video.other' && openGraph.video)}
+      {:else if ['video.movie', 'video.episode', 'video.tv_show'].includes(openGraph.type.toLowerCase()) || (openGraph.type.toLowerCase() === 'video.other' && openGraph.video)}
         {#each openGraph.video?.actors as actor (actor)}
           {#if actor.profile}
             <meta property="video:actor" content={actor.profile} />


### PR DESCRIPTION
just a few nits and here there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of generated head and social preview tags when optional metadata fields (titles, language alternates, Open Graph authors/tags, and media items like images/videos/audio) are missing or partially provided.
  * Ensured additional meta and link tags/values render consistently instead of being skipped due to conditional wrappers.
* **Refactor**
  * Simplified template rendering for optional iterables by replacing length/truthy guards with direct loops driven by optional chaining, and streamlined title derivation logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->