### PR TITLE
fix: prevent `httpEquiv` prop from leaking onto `additionalMetaTags` meta tags

### DIFF
--- a/.changeset/fix-additional-meta-tags-httpequiv-leak.md
+++ b/.changeset/fix-additional-meta-tags-httpequiv-leak.md
@@ -1,0 +1,5 @@
+---
+'svelte-meta-tags': patch
+---
+
+fix: prevent the internal `httpEquiv` prop from leaking as an attribute on `additionalMetaTags` `<meta>` tags; only the mapped `http-equiv` attribute is rendered now

--- a/packages/svelte-meta-tags/src/lib/MetaTags.svelte
+++ b/packages/svelte-meta-tags/src/lib/MetaTags.svelte
@@ -311,7 +311,8 @@
   {/if}
 
   {#each additionalMetaTags as tag (tag)}
-    <meta {...tag.httpEquiv ? { ...tag, 'http-equiv': tag.httpEquiv } : tag} />
+    {@const { httpEquiv, ...metaTag } = tag}
+    <meta {...httpEquiv ? { ...metaTag, 'http-equiv': httpEquiv } : metaTag} />
   {/each}
 
   {#each additionalLinkTags as tag (tag)}

--- a/tests/svelte-5/tests/another.test.ts
+++ b/tests/svelte-5/tests/another.test.ts
@@ -40,4 +40,6 @@ test('Another pattern SEO loads correctly', async ({ page }) => {
   await expect(page.locator('head meta[property="dc:creator"]')).toHaveAttribute('content', 'Jane Doe');
   await expect(page.locator('head meta[name="application-name"]')).toHaveAttribute('content', 'Svelte-Meta-Tags');
   await expect(page.locator('head meta[http-equiv="x-ua-compatible"]')).toHaveAttribute('content', 'IE=edge; chrome=1');
+  // The internal camelCase `httpEquiv` prop must not leak into the rendered markup
+  await expect(page.locator('head meta[httpequiv]')).toHaveCount(0);
 });


### PR DESCRIPTION
## What

`additionalMetaTags` entries that use `httpEquiv` rendered **both** the internal camelCase `httpEquiv` attribute and the correct `http-equiv` attribute:

```html
<\!-- before -->
<meta httpequiv="x-ua-compatible" content="IE=edge" http-equiv="x-ua-compatible" />
<\!-- after -->
<meta content="IE=edge" http-equiv="x-ua-compatible" />
```

The spread `{ ...tag, 'http-equiv': tag.httpEquiv }` kept the original `httpEquiv` key, so it leaked onto the element.

## Fix

Destructure `httpEquiv` out of the tag and spread only the rest:

```svelte
{#each additionalMetaTags as tag (tag)}
  {@const { httpEquiv, ...metaTag } = tag}
  <meta {...httpEquiv ? { ...metaTag, 'http-equiv': httpEquiv } : metaTag} />
{/each}
```

`{@const}` is valid across all of Svelte 5.x, so there is no impact on the `^5.0.0` peer range. `httpEquiv` is a common property of the `MetaTag` union, so the destructure is type-safe.

## Test

`another.test.ts` previously only asserted that `http-equiv` was present, which is why the leak went unnoticed. Added a regression assertion that the camelCase `httpequiv` attribute is **not** emitted:

```ts
await expect(page.locator('head meta[httpequiv]')).toHaveCount(0);
```

## Notes

- Pre-existing bug surfaced by CodeRabbit during #2115; intentionally kept out of that refactor PR's scope and addressed here.
- Behavior verified locally via SSR rendering; full `package` / `check` / e2e run on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented extra meta-tag attributes from appearing in rendered HTML.
  * Ensured only the standard `http-equiv` attribute is output when applicable.
* **Tests**
  * Added coverage to confirm the unwanted camelCase attribute is no longer present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->