### PR TITLE
docs: add spec and implementation plan for Starlight → blume migration

### DIFF
--- a/superpowers/plans/2026-07-15-blume-migration.md
+++ b/superpowers/plans/2026-07-15-blume-migration.md
@@ -67,9 +67,16 @@ Types                 ← グループ, meta.ts order: 4
 
 `catalog:` から `'@astrojs/check'`、`'@astrojs/starlight'`、`astro`、`sharp` の4行を削除し（docs 専用依存。他ワークスペースでの未使用は確認済み）、`blume` をアルファベット順の位置（`astro` があった行の位置）に追加する。`allowBuilds:` から `sharp: true` を削除する（`esbuild: true` は残す）。
 
+また、blume 1.0.3 は公開から3日未満で `minimumReleaseAge: 4320` に弾かれるため、`minimumReleaseAgeExclude` に `blume` を追加する（ユーザー承認済み。`minimumReleaseAge` 自体は維持）。
+
 変更後の該当ブロック:
 
 ```yaml
+minimumReleaseAge: 4320
+
+minimumReleaseAgeExclude:
+  - blume
+
 allowBuilds:
   esbuild: true
 

--- a/superpowers/plans/2026-07-15-blume-migration.md
+++ b/superpowers/plans/2026-07-15-blume-migration.md
@@ -1,0 +1,802 @@
+# Starlight → blume 移行 実装計画
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `docs/` の Astro + Starlight 製ドキュメントサイトを blume v1.0.3 に置き換え、英語 + 日本語の2ロケールと GitHub Pages（`/svelte-meta-tags` サブパス）デプロイを維持する。
+
+**Architecture:** blume はコンテンツフォルダ（`docs/content/`）をスキャンして静的サイトを生成する markdown-first フレームワーク。設定は `blume.config.ts` 1ファイル、サイドバーはファイル構造 + フォルダごとの `meta.ts` から自動生成。日本語は `content/ja/` ミラーで、未翻訳ページは英語に自動フォールバックする。
+
+**Tech Stack:** blume ^1.0.3（Astro + Vite 内包）、pnpm workspace（catalog 方式）、GitHub Pages（`actions/upload-pages-artifact` + `actions/deploy-pages`）
+
+**Spec:** `superpowers/specs/2026-07-15-blume-migration-design.md`
+
+## Global Constraints
+
+- blume は `^1.0.3`、Node 22.12+（リポジトリは 24.17.0 で充足。ルート `package.json` の `devEngines` / `packageManager` は変更しない）
+- 依存バージョンは `pnpm-workspace.yaml` の `catalog:` に置き、`docs/package.json` からは `"catalog:"` で参照する（直接ピン禁止）
+- `pnpm-workspace.yaml` の `minimumReleaseAge: 4320` は維持する
+- GitHub Actions は必ず commit SHA ピン + `# vX.Y.Z` コメント（bare タグ禁止）
+- Prettier: 120桁・シングルクォート・trailing comma なし。各タスクのコミット前に `pnpm format` 相当が通ること
+- changeset は**不要**（docs サイトのみの内部変更）
+- 作業ブランチ: `docs/migrate-to-blume`（作成済み）
+- サンドボックスで `pnpm install` がブロックされた場合は、ユーザーに `! pnpm install` の実行を依頼する（勝手な回避策をとらない）
+
+## 新旧対応の全体マップ
+
+| 現在（Starlight） | 移行後（blume） |
+| --- | --- |
+| `docs/astro.config.mjs` | `docs/blume.config.ts` |
+| `docs/src/content/docs/**` | `docs/content/**` |
+| `docs/src/content/docs/ja/**` | `docs/content/ja/**` |
+| `docs/src/assets/*.svg` | `docs/public/*.svg` |
+| `docs/src/styles/custom.css` | 廃止（Task 8 の目視確認で表が崩れる場合のみ `docs/theme.css` を追加） |
+| `docs/src/content.config.ts` | 廃止（blume が内部処理） |
+| `docs/tsconfig.json` | 廃止（blume が `.blume/` 内で管理） |
+| astro.config の `sidebar` + `translations` | フォルダ `meta.ts` / `meta.$.ts` + ページ frontmatter `sidebar.order` |
+| `withastro/action` | `pnpm --filter docs build` + Pages 公式アクション |
+
+サイドバーの最終形（en。ja は同構造で `meta.ts` のラベルが翻訳される）:
+
+```
+(index)               ← content/index.mdx
+Installing            ← ページ, sidebar.order: 1
+Usage                 ← ページ, sidebar.order: 2
+Deep Merge function   ← ページ, sidebar.order: 3
+Migration Guide       ← ページ, sidebar.order: 4
+MetaTags Properties   ← グループ, meta.ts order: 1
+Open Graph            ← グループ, meta.$.ts order: 2
+JSON-LD               ← グループ, meta.$.ts order: 3
+Types                 ← グループ, meta.ts order: 4
+```
+
+※ blume の flat 表示ではグループ外ページが常にグループ群の上に表示される（スペック承認済みの並び）。
+
+---
+
+### Task 1: 依存関係を blume に切り替える
+
+**Files:**
+- Modify: `pnpm-workspace.yaml`
+- Modify: `docs/package.json`
+- Modify: `.gitignore`
+
+**Interfaces:**
+- Produces: `pnpm --filter docs exec blume <cmd>` が動く状態（以降の全タスクが依存）
+
+- [ ] **Step 1: `pnpm-workspace.yaml` の catalog を更新**
+
+`catalog:` から `'@astrojs/check'`、`'@astrojs/starlight'`、`astro`、`sharp` の4行を削除し（docs 専用依存。他ワークスペースでの未使用は確認済み）、`blume` をアルファベット順の位置（`astro` があった行の位置）に追加する。`allowBuilds:` から `sharp: true` を削除する（`esbuild: true` は残す）。
+
+変更後の該当ブロック:
+
+```yaml
+allowBuilds:
+  esbuild: true
+
+catalog:
+  '@changesets/cli': ^2.31.0
+  '@eslint/compat': ^2.1.0
+  '@eslint/js': ^10.0.1
+  '@playwright/test': ^1.61.1
+  '@sveltejs/adapter-auto': ^7.0.1
+  '@sveltejs/kit': ^2.69.2
+  '@sveltejs/package': ^2.5.8
+  '@sveltejs/vite-plugin-svelte': ^7.2.0
+  '@types/eslint': ^9.6.1
+  blume: ^1.0.3
+  eslint: ^10.7.0
+```
+
+（`eslint` 以降の既存行は変更しない。`minimumReleaseAge: 4320` と `packages:` はそのまま）
+
+- [ ] **Step 2: `docs/package.json` を書き換え**
+
+全文をこの内容にする:
+
+```json
+{
+  "name": "docs",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "blume dev",
+    "start": "blume dev",
+    "check": "blume check",
+    "build": "blume build",
+    "preview": "blume preview"
+  },
+  "dependencies": {
+    "blume": "catalog:",
+    "typescript": "catalog:"
+  }
+}
+```
+
+（`typescript` は `blume check`（内部で `astro check`）のために残す。`astro` スクリプトエントリは削除）
+
+- [ ] **Step 3: ルート `.gitignore` に `.blume/` を追加**
+
+`.astro/` の行の直後に追加:
+
+```
+.astro/
+.blume/
+```
+
+（`dist` は既存の行がカバーしている）
+
+- [ ] **Step 4: インストール**
+
+Run: `pnpm install`
+Expected: エラーなく完了。`docs/node_modules/.bin/blume` が存在する。
+
+- [ ] **Step 5: blume が動くことを確認**
+
+Run: `pnpm --filter docs exec blume --version`
+Expected: `1.0.3`（またはそれ以降の 1.0.x）
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add pnpm-workspace.yaml docs/package.json .gitignore pnpm-lock.yaml
+git commit -m "docs: replace starlight deps with blume"
+```
+
+---
+
+### Task 2: blume.config.ts とアセットを作成し初回ビルドを通す
+
+**Files:**
+- Create: `docs/blume.config.ts`
+- Create: `docs/content/index.mdx`
+- Move: `docs/src/assets/light-logo.svg` → `docs/public/light-logo.svg`
+- Move: `docs/src/assets/dark-logo.svg` → `docs/public/dark-logo.svg`
+- Delete: `docs/tsconfig.json`
+
+**Interfaces:**
+- Produces: `pnpm --filter docs build` が成功する blume プロジェクトの骨格。`content/` 直下が以降のタスクのコンテンツ配置先。
+
+- [ ] **Step 1: ロゴを public/ へ移動**
+
+```bash
+git mv docs/src/assets/light-logo.svg docs/public/light-logo.svg
+git mv docs/src/assets/dark-logo.svg docs/public/dark-logo.svg
+```
+
+（`docs/public/favicon.svg` は既存のまま。blume は `public/` の favicon ファイルを自動検出するため設定不要）
+
+- [ ] **Step 2: `docs/blume.config.ts` を作成**
+
+```ts
+import { defineConfig } from 'blume';
+
+export default defineConfig({
+  title: 'SvelteMetaTags',
+  description: 'Svelte Meta Tags provides components designed to help you manage SEO for Svelte projects.',
+  content: { root: 'content' },
+  logo: {
+    image: { light: '/light-logo.svg', dark: '/dark-logo.svg', alt: 'SvelteMetaTags' },
+    text: ''
+  },
+  github: { owner: 'oekazuma', repo: 'svelte-meta-tags', dir: 'docs' },
+  i18n: {
+    defaultLocale: 'en',
+    locales: [
+      { code: 'en', label: 'English' },
+      { code: 'ja', label: '日本語' }
+    ]
+  },
+  deployment: {
+    site: 'https://oekazuma.github.io',
+    base: '/svelte-meta-tags'
+  }
+});
+```
+
+（`content.root` のデフォルトは `docs` のため明示必須。`logo.text: ''` は現行 Starlight の `replacesTitle: true` 相当＝ロゴ画像単独表示。`redirects` は Task 6 で必要になった場合のみ追加）
+
+- [ ] **Step 3: トップページ `docs/content/index.mdx` を作成**
+
+現行 `docs/src/content/docs/index.mdx`（splash + hero）の置き換え。blume には splash テンプレートがないため通常ページ化する（スペック承認済み）:
+
+```mdx
+---
+title: Svelte Meta Tags
+description: Svelte Meta Tags provides components designed to help you manage SEO for Svelte projects.
+seo:
+  title: Svelte Meta Tags ・ Components to manage SEO
+  description: Svelte Meta Tags is a Svelte library to manage SEO meta tags in your Svelte applications. It provides a set of components to manage the meta tags in your Svelte applications.
+---
+
+<CardGroup cols={2}>
+  <Card title="Effortless SEO Management" icon="rocket">
+    Easily manage SEO meta tags with a simple interface for more effective search engine optimization.
+  </Card>
+  <Card title="JSON-LD Support" icon="file-text">
+    Offers JSON-LD support for structured data, which is essential for search engine optimization.
+  </Card>
+  <Card title="Deep Merge Functionality" icon="puzzle">
+    The deep merge function allows you to easily manage meta tags in complex Svelte applications.
+  </Card>
+  <Card title="TypeScript Friendly" icon="code">
+    Includes TypeScript support to help you manage meta tags in a type-safe way.
+  </Card>
+</CardGroup>
+
+<CardGroup cols={2}>
+  <Card title="Get started" icon="arrow-right" href="/installing">
+    Install Svelte Meta Tags and set up your first meta tags.
+  </Card>
+  <Card title="View on GitHub" icon="github" href="https://github.com/oekazuma/svelte-meta-tags">
+    Browse the source, open issues, and contribute.
+  </Card>
+</CardGroup>
+```
+
+注意: blume のアイコンは Lucide 名（kebab-case）。Starlight の `document` → `file-text`、`seti:typescript` → `code` に置換している。`Card`/`CardGroup` は組み込みで import 不要。内部リンクは `/installing` のように base 抜きで書く（blume が `deployment.base` を付けて書き換える）。
+
+- [ ] **Step 4: 旧 tsconfig を削除**
+
+```bash
+git rm docs/tsconfig.json
+```
+
+- [ ] **Step 5: ビルド確認**
+
+Run: `pnpm --filter docs build`
+Expected: `[build] Complete!` とビルドサマリー（`Output static` / `Search orama` / `Sitemap yes`）が出て `docs/dist/` が生成される。旧 `docs/src/content/docs/**` はまだ残っているが、blume は `content/` しか見ないため干渉しない。
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add docs/blume.config.ts docs/content/index.mdx docs/public docs/src/assets docs/tsconfig.json
+git commit -m "docs: scaffold blume config, top page, and assets"
+```
+
+---
+
+### Task 3: 英語コンテンツを移行する
+
+**Files:**
+- Move+Modify: `docs/src/content/docs/**`（`ja/` 以外の全ファイル）→ `docs/content/**`
+- Create: `docs/content/meta-tags-properties/meta.ts`、`docs/content/open-graph/meta.$.ts`、`docs/content/json-ld/meta.$.ts`、`docs/content/json-ld/json-ld-properties/meta.$.ts`、`docs/content/types/meta.ts`、`docs/content/types/additional-types/meta.$.ts`
+
+**Interfaces:**
+- Consumes: Task 2 の `docs/content/` と `blume.config.ts`
+- Produces: 英語全ページのルート（`/installing`、`/meta-tags-properties/...` 等）。Task 4 の `ja/` ミラーはこの構造に対応させる。
+
+- [ ] **Step 1: ディレクトリごと移動するグループをまとめて git mv**
+
+```bash
+git mv docs/src/content/docs/meta-tags-properties docs/content/meta-tags-properties
+git mv docs/src/content/docs/open-graph docs/content/open-graph
+git mv docs/src/content/docs/json-ld docs/content/json-ld
+git mv docs/src/content/docs/types docs/content/types
+```
+
+（各ページの frontmatter `title` / `description` / `sidebar.order` は blume 互換なので中身は無変更。例外は Step 4 の `json-ld-multiple-examples.mdx` のみ）
+
+- [ ] **Step 2: フラット化する4ページを移動**
+
+```bash
+git mv docs/src/content/docs/installing/index.mdx docs/content/installing.mdx
+git mv docs/src/content/docs/usage/index.mdx docs/content/usage.mdx
+git mv docs/src/content/docs/deep-merge-function/index.md docs/content/deep-merge-function.md
+git mv docs/src/content/docs/migration-guide/index.md docs/content/migration-guide.md
+```
+
+旧 `docs/src/content/docs/index.mdx` は Task 2 で新規作成済みのため削除:
+
+```bash
+git rm docs/src/content/docs/index.mdx
+```
+
+- [ ] **Step 3: フラット化4ページの frontmatter に並び順を追加し、コンポーネントを変換**
+
+`docs/content/installing.mdx` — 全文をこの内容にする（Starlight `Tabs/TabItem` → blume `CodeGroup`。タブラベルは各コードブロックの言語名の後のテキスト）:
+
+````mdx
+---
+title: Installing
+sidebar:
+  order: 1
+---
+
+<CodeGroup>
+
+```sh npm
+npm install -D svelte-meta-tags
+```
+
+```sh pnpm
+pnpm add -D svelte-meta-tags
+```
+
+```sh Yarn
+yarn add -D svelte-meta-tags
+```
+
+</CodeGroup>
+````
+
+`docs/content/usage.mdx` — frontmatter を以下に変更し、`import { LinkButton } ...` 行と `<LinkButton ...>Demo</LinkButton>` ブロックを Markdown リンクに置換する。それ以降の本文（コード例）は無変更:
+
+```mdx
+---
+title: Usage
+sidebar:
+  order: 2
+---
+
+[Demo ↗](https://svelte.dev/repl/ffd783c9b8e54d97b6b7cac6eadace42)
+```
+
+`docs/content/deep-merge-function.md` — frontmatter に追加（本文無変更）:
+
+```yaml
+sidebar:
+  order: 3
+```
+
+`docs/content/migration-guide.md` — frontmatter に追加（本文無変更）:
+
+```yaml
+sidebar:
+  order: 4
+```
+
+- [ ] **Step 4: `json-ld-multiple-examples.mdx` の Aside を変換**
+
+`docs/content/json-ld/json-ld-properties/json-ld-multiple-examples.mdx` の `import { Aside } from '@astrojs/starlight/components';` 行を削除し、
+
+```mdx
+<Aside type="caution">
+  Safari will log an error to the console when you use an array to describe multiple data items. Although the library
+  functions correctly, be cautious if you're aggregating error logs with tools like Sentry. To avoid this issue,
+  consider using @graph.
+</Aside>
+```
+
+を次に置換する:
+
+```mdx
+:::caution
+Safari will log an error to the console when you use an array to describe multiple data items. Although the library
+functions correctly, be cautious if you're aggregating error logs with tools like Sentry. To avoid this issue,
+consider using @graph.
+:::
+```
+
+- [ ] **Step 5: グループの meta ファイルを作成**
+
+`$` 付きファイル（`meta.$.ts`）は全ロケール共有（en/ja でラベルが同じグループ用）。`meta.ts` はロケール別（Task 4 で ja 側に翻訳版を作るグループ用）。
+
+`docs/content/meta-tags-properties/meta.ts`:
+
+```ts
+import { defineMeta } from 'blume';
+
+export default defineMeta({
+  title: 'MetaTags Properties',
+  order: 1
+});
+```
+
+`docs/content/open-graph/meta.$.ts`:
+
+```ts
+import { defineMeta } from 'blume';
+
+export default defineMeta({
+  title: 'Open Graph',
+  order: 2
+});
+```
+
+`docs/content/json-ld/meta.$.ts`:
+
+```ts
+import { defineMeta } from 'blume';
+
+export default defineMeta({
+  title: 'JSON-LD',
+  order: 3
+});
+```
+
+（フォルダ名の humanize では "Json Ld" になってしまうため title 指定が必須）
+
+`docs/content/json-ld/json-ld-properties/meta.$.ts`:
+
+```ts
+import { defineMeta } from 'blume';
+
+export default defineMeta({
+  title: 'JSON-LD Properties'
+});
+```
+
+`docs/content/types/meta.ts`:
+
+```ts
+import { defineMeta } from 'blume';
+
+export default defineMeta({
+  title: 'Types',
+  order: 4
+});
+```
+
+`docs/content/types/additional-types/meta.$.ts`:
+
+```ts
+import { defineMeta } from 'blume';
+
+export default defineMeta({
+  title: 'Additional types'
+});
+```
+
+- [ ] **Step 6: ビルドとリンク検証**
+
+Run: `pnpm --filter docs build`
+Expected: 成功。ページ数が en 全ページ分（40ページ前後）に増える。
+
+Run: `pnpm --filter docs exec blume validate`
+Expected: リンク切れ 0 件。`/svelte-meta-tags/...` のような base 込みで書かれた内部リンクがあれば警告されるので、base 抜き（`/installing` 形式）に修正する。
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add docs/content docs/src
+git commit -m "docs: migrate English content to blume conventions"
+```
+
+---
+
+### Task 4: 日本語コンテンツを移行する
+
+**Files:**
+- Move+Modify: `docs/src/content/docs/ja/**` → `docs/content/ja/**`
+- Create: `docs/content/ja/meta-tags-properties/meta.ts`、`docs/content/ja/types/meta.ts`
+
+**Interfaces:**
+- Consumes: Task 3 の en 構造（ja はそのミラー）。共有 `meta.$.ts`（Open Graph / JSON-LD / JSON-LD Properties / Additional types）は ja にも自動適用される。
+- Produces: `/ja/...` 全ルートと日本語サイドバー。
+
+- [ ] **Step 1: ディレクトリごと移動**
+
+```bash
+git mv docs/src/content/docs/ja/meta-tags-properties docs/content/ja/meta-tags-properties
+git mv docs/src/content/docs/ja/open-graph docs/content/ja/open-graph
+git mv docs/src/content/docs/ja/json-ld docs/content/ja/json-ld
+git mv docs/src/content/docs/ja/types docs/content/ja/types
+```
+
+- [ ] **Step 2: フラット化する4ページを移動**
+
+```bash
+git mv docs/src/content/docs/ja/installing/index.mdx docs/content/ja/installing.mdx
+git mv docs/src/content/docs/ja/usage/index.mdx docs/content/ja/usage.mdx
+git mv docs/src/content/docs/ja/deep-merge-function/index.md docs/content/ja/deep-merge-function.md
+git mv docs/src/content/docs/ja/migration-guide/index.md docs/content/ja/migration-guide.md
+```
+
+- [ ] **Step 3: ja トップページを作成**
+
+`docs/src/content/docs/ja/index.mdx` を `docs/content/ja/index.mdx` に置き換える。en 版（Task 2 Step 3）と同じ構造で、テキストは既存 ja 版から引き継ぐ。全文:
+
+```mdx
+---
+title: Svelte Meta Tags
+description: Svelte Meta Tagsは、SvelteプロジェクトのSEOを管理するために設計されたコンポーネントを提供します。
+seo:
+  title: Svelte Meta Tags ・ SEOを管理するためのコンポーネント
+  description: Svelte Meta Tagsは、SvelteアプリケーションのSEOメタタグを管理するためのSvelteライブラリです。Svelteアプリケーションのメタタグを管理するためのコンポーネント群を提供します。
+---
+
+<CardGroup cols={2}>
+  <Card title="効率的なSEO管理" icon="rocket">
+    シンプルなインターフェイスでSEOメタタグを簡単に管理し、より効果的な検索エンジン最適化を実現します。
+  </Card>
+  <Card title="JSON-LDのサポート" icon="file-text">
+    検索エンジン最適化に不可欠な構造化データのJSON-LDサポートを提供します。
+  </Card>
+  <Card title="ディープマージ機能" icon="puzzle">
+    ディープマージ機能により、複雑なSvelteアプリケーションのmetaタグを簡単に管理できます。
+  </Card>
+  <Card title="TypeScript フレンドリー" icon="code">
+    TypeScriptをサポートしており、タイプセーフな方法でメタタグを管理できます。
+  </Card>
+</CardGroup>
+
+<CardGroup cols={2}>
+  <Card title="はじめる" icon="arrow-right" href="/ja/installing">
+    Svelte Meta Tags をインストールして最初のメタタグを設定します。
+  </Card>
+  <Card title="GitHubを見る" icon="github" href="https://github.com/oekazuma/svelte-meta-tags">
+    ソースの閲覧、Issue の起票、コントリビュートはこちら。
+  </Card>
+</CardGroup>
+```
+
+旧ファイルを削除:
+
+```bash
+git rm docs/src/content/docs/ja/index.mdx
+```
+
+- [ ] **Step 4: ja のフラット化4ページとコンポーネントを en と同一ルールで変換**
+
+`docs/content/ja/installing.mdx` — frontmatter を `title: インストール` のまま `sidebar.order: 1` を追加し、本文の `Tabs/TabItem`（import 行含む）を en 版（Task 3 Step 3）と同じ `CodeGroup` ブロックに置換する（コマンド内容は同一）。
+
+`docs/content/ja/usage.mdx` — `sidebar.order: 2` を追加。`import { LinkButton } ...` 行と `<LinkButton ...>` ブロックを `[Demo ↗](https://svelte.dev/repl/ffd783c9b8e54d97b6b7cac6eadace42)` に置換。本文のコード例は無変更。
+
+`docs/content/ja/deep-merge-function.md` — `sidebar.order: 3` を追加（本文無変更）。
+
+`docs/content/ja/migration-guide.md` — `sidebar.order: 4` を追加（本文無変更）。
+
+`docs/content/ja/json-ld/json-ld-properties/json-ld-multiple-examples.mdx` — `import { Aside } ...` 行を削除し、`<Aside type="caution">...</Aside>` を `:::caution` / `:::` 記法に置換（中の日本語テキストはそのまま）。
+
+- [ ] **Step 5: ja のロケール別 meta.ts を作成**
+
+`docs/content/ja/meta-tags-properties/meta.ts`:
+
+```ts
+import { defineMeta } from 'blume';
+
+export default defineMeta({
+  title: 'MetaTagsプロパティ',
+  order: 1
+});
+```
+
+`docs/content/ja/types/meta.ts`:
+
+```ts
+import { defineMeta } from 'blume';
+
+export default defineMeta({
+  title: '型定義',
+  order: 4
+});
+```
+
+（Open Graph / JSON-LD / JSON-LD Properties / Additional types は en 側の `meta.$.ts` が全ロケールに適用されるため ja 側は不要）
+
+- [ ] **Step 6: 残骸ディレクトリの確認**
+
+Run: `find docs/src -type f`
+Expected: `docs/src/content.config.ts` と `docs/src/styles/custom.css` のみが残る（Task 5 で撤去）。他のファイルが残っていれば移行漏れなので Step 1〜4 を見直す。
+
+- [ ] **Step 7: ビルドとリンク検証**
+
+Run: `pnpm --filter docs build`
+Expected: 成功。ページ数が en + ja 全ページ分（80ページ前後）になる。
+
+Run: `pnpm --filter docs exec blume validate`
+Expected: リンク切れ 0 件。
+
+- [ ] **Step 8: コミット**
+
+```bash
+git add docs/content docs/src
+git commit -m "docs: migrate Japanese content to blume conventions"
+```
+
+---
+
+### Task 5: Starlight の残骸を撤去する
+
+**Files:**
+- Delete: `docs/astro.config.mjs`、`docs/src/`（`content.config.ts`、`styles/custom.css`）、`docs/README.md`（空ファイル）
+
+**Interfaces:**
+- Consumes: Task 3・4 でコンテンツ移動が完了していること
+- Produces: blume のみで完結した `docs/` ワークスペース
+
+- [ ] **Step 1: 撤去**
+
+```bash
+git rm docs/astro.config.mjs
+git rm -r docs/src
+git rm docs/README.md
+```
+
+注意: `docs/src/styles/custom.css` の中身は `th, td { min-width: 100px; }` のみ。blume のデフォルトテーブルスタイルで問題ないか Task 8 の目視確認で判断し、崩れる場合のみそこで `docs/theme.css` を追加する（このタスクでは持ち込まない）。
+
+- [ ] **Step 2: フル検証**
+
+Run: `pnpm --filter docs build && pnpm --filter docs check`
+Expected: 両方成功。
+
+Run: `pnpm --filter docs exec blume doctor`
+Expected: 設定・コンテンツの診断エラー 0 件。
+
+- [ ] **Step 3: フォーマットと lint**
+
+Run: `pnpm format && pnpm lint`
+Expected: `pnpm lint` が成功（prettier が新規 `.ts` / `.mdx` を整形済みであること）。
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add -A docs
+git commit -m "docs: remove starlight scaffolding"
+```
+
+---
+
+### Task 6: 新旧 URL を突合し redirects を確定する
+
+**Files:**
+- Modify: `docs/blume.config.ts`（差分があった場合のみ）
+
+**Interfaces:**
+- Consumes: Task 5 までの完成した `docs/dist/`
+- Produces: 旧 URL がすべて生きていることの保証（`redirects` 配列 or 差分ゼロの確認記録）
+
+- [ ] **Step 1: 本番サイトの URL 一覧を取得**
+
+Run:
+
+```bash
+curl -s https://oekazuma.github.io/svelte-meta-tags/sitemap-0.xml | grep -o '<loc>[^<]*</loc>' | sed -e 's/<\/\?loc>//g' -e 's|https://oekazuma.github.io/svelte-meta-tags||' -e 's|/$||' | sort > /tmp/claude/old-urls.txt
+```
+
+（`sitemap-0.xml` が 404 の場合は `sitemap-index.xml` を見て実ファイル名を確認する）
+
+- [ ] **Step 2: 新ビルドの URL 一覧を生成**
+
+Run:
+
+```bash
+cd docs/dist && find . -name 'index.html' | sed -e 's|^\.||' -e 's|/index.html$||' -e 's|^$|/|' | sed 's|^/svelte-meta-tags||' | sort > /tmp/claude/new-urls.txt && cd -
+```
+
+（`deployment.base` 設定により dist 直下が `svelte-meta-tags/` 配下になっている場合は sed が吸収する。構造が違ったら実際の dist を見て調整する）
+
+- [ ] **Step 3: 突合**
+
+Run: `comm -23 /tmp/claude/old-urls.txt /tmp/claude/new-urls.txt`
+Expected: **空**（旧 URL がすべて新ビルドに存在する）。
+
+出力がある場合、それが「旧にあって新にない」URL。各行について `docs/blume.config.ts` に redirect を追加する:
+
+```ts
+redirects: [
+  { from: '/old-path', to: '/new-path' }
+]
+```
+
+追加後 `pnpm --filter docs build` を再実行し、Step 2〜3 を繰り返して空になることを確認する。ビルドサマリーの `Redirects` 行の件数が追加分と一致すること。
+
+- [ ] **Step 4: コミット（redirects を追加した場合のみ）**
+
+```bash
+git add docs/blume.config.ts
+git commit -m "docs: add redirects for moved pages"
+```
+
+---
+
+### Task 7: GitHub Pages デプロイワークフローを更新する
+
+**Files:**
+- Modify: `.github/workflows/deploy-docs.yml`
+
+**Interfaces:**
+- Consumes: Task 1 の `docs` build スクリプト（`blume build`）、既存 composite action `.github/workflows/setup-node/`（Node/pnpm をルート `package.json` から解決）
+- Produces: main マージ時に blume ビルドを GitHub Pages へ公開するワークフロー
+
+- [ ] **Step 1: `deploy-docs.yml` を書き換え**
+
+全文をこの内容にする（`deploy` ジョブは現行のまま）:
+
+```yaml
+name: Deploy for Docs to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout your repository using git
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Setup Node.js and dependencies
+        uses: ./.github/workflows/setup-node
+      - name: Build docs
+        run: pnpm --filter docs build
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
+        with:
+          path: docs/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+```
+
+（Node/pnpm バージョン取得ステップは composite action `setup-node` が担うため削除。SHA は検証済み: configure-pages v5.0.0 = `983d773…`、upload-pages-artifact v4.0.0 = `7b1f4a7…`。既存の checkout / deploy-pages の SHA は現行ファイルのまま）
+
+- [ ] **Step 2: lint 確認**
+
+Run: `pnpm lint`
+Expected: 成功（prettier が YAML も検査するため）。
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add .github/workflows/deploy-docs.yml
+git commit -m "ci: build docs with blume for GitHub Pages"
+```
+
+---
+
+### Task 8: 最終検証（プレビュー目視）
+
+**Files:**
+- Create（必要時のみ）: `docs/theme.css`
+
+**Interfaces:**
+- Consumes: 全タスクの成果物
+
+- [ ] **Step 1: フルチェーンを一括実行**
+
+Run: `pnpm install && pnpm lint && pnpm --filter docs check && pnpm --filter docs build && pnpm --filter docs exec blume validate && pnpm --filter docs exec blume doctor`
+Expected: すべて成功。ビルドサマリーで `Sitemap yes` / `LLM files yes` / `Search orama` を確認。
+
+- [ ] **Step 2: プレビューを起動しユーザーに目視確認を依頼**
+
+Run: `pnpm --filter docs preview`
+
+ユーザーに `http://localhost:4321/svelte-meta-tags/` を開いて以下の確認を依頼する:
+
+1. トップページ（en / ja）の表示とカードリンク
+2. サイドバーの並びとラベル（en: Installing → Usage → Deep Merge function → Migration Guide → MetaTags Properties → Open Graph → JSON-LD → Types。ja は翻訳ラベル）
+3. 言語スイッチャーで en ⇄ ja が対応ページ同士で切り替わること
+4. 検索（日本語ページで日本語結果が出ること）
+5. `Types` 配下など表の多いページで表の見た目が崩れていないこと
+6. ライト/ダーク切り替えでロゴが正しく切り替わること
+
+- [ ] **Step 3（表が崩れた場合のみ）: theme.css を追加**
+
+`docs/theme.css` を作成:
+
+```css
+th,
+td {
+  min-width: 100px;
+}
+```
+
+再ビルドして確認後:
+
+```bash
+git add docs/theme.css
+git commit -m "docs: keep table cell min-width from starlight theme"
+```
+
+- [ ] **Step 4: 仕上げ**
+
+superpowers:finishing-a-development-branch スキルに従い、PR 作成などの統合方法をユーザーに確認する。PR 本文には移行内容の要約と、デプロイは main マージ後に `deploy-docs.yml` が走ることを記載する。

--- a/superpowers/plans/2026-07-15-blume-migration.md
+++ b/superpowers/plans/2026-07-15-blume-migration.md
@@ -10,6 +10,11 @@
 
 **Spec:** `superpowers/specs/2026-07-15-blume-migration-design.md`
 
+> **⚠️ ステータス（2026-07-15 時点）: 実装は blume の次期リリース待ちで中断中。**
+> blume 1.0.3 には pnpm の隔離型 node_modules（isolated linker）で、生成される `.blume/` ランタイムが `astro` 等を解決できないバグがある（`.blume/node_modules` のシンボリックリンクが pnpm の sibling レイアウトを想定していない）。修正は upstream の main にマージ済みだが 1.0.3 リリース（2026-07-13）より後のため未リリース。
+> **再開条件:** blume 1.0.4+ がリリースされたら catalog のレンジで取り込まれるので、Task 2 のビルド検証から再開する。待てない場合の既知の回避策: `astro` / `@astrojs/mdx` / `@shikijs/twoslash` / `@tailwindcss/vite` / `@orama/orama` を blume と同じレンジで docs の依存に一時追加する（1.0.4 で削除）。
+> Task 1（依存切り替え）と Task 2 のファイル作成までは検証済み（`blume --version` = 1.0.3 で動作、ビルドのみ上記バグで失敗）。
+
 ## Global Constraints
 
 - blume は `^1.0.3`、Node 22.12+（リポジトリは 24.17.0 で充足。ルート `package.json` の `devEngines` / `packageManager` は変更しない）

--- a/superpowers/plans/2026-07-15-blume-migration.md
+++ b/superpowers/plans/2026-07-15-blume-migration.md
@@ -12,8 +12,9 @@
 
 > **⚠️ ステータス（2026-07-15 時点）: 実装は blume の次期リリース待ちで中断中。**
 > blume 1.0.3 には pnpm の隔離型 node_modules（isolated linker）で、生成される `.blume/` ランタイムが `astro` 等を解決できないバグがある（`.blume/node_modules` のシンボリックリンクが pnpm の sibling レイアウトを想定していない）。修正は upstream の main にマージ済みだが 1.0.3 リリース（2026-07-13）より後のため未リリース。
-> **再開条件:** blume 1.0.4+ がリリースされたら catalog のレンジで取り込まれるので、Task 2 のビルド検証から再開する。待てない場合の既知の回避策: `astro` / `@astrojs/mdx` / `@shikijs/twoslash` / `@tailwindcss/vite` / `@orama/orama` を blume と同じレンジで docs の依存に一時追加する（1.0.4 で削除）。
-> Task 1（依存切り替え）と Task 2 のファイル作成までは検証済み（`blume --version` = 1.0.3 で動作、ビルドのみ上記バグで失敗）。
+> **再開条件:** blume 1.0.4+（isolated linker 修正版）のリリース後に **Task 1 から** 再実行する（Task 1〜2 の実装コミットは破棄済み。内容は本計画に完全な形で記載されている）。Task 1 の `pnpm install` で lockfile が新規生成され、catalog の `^1.0.3` は最新の修正版に解決される（blume は `minimumReleaseAgeExclude` 対象のため公開直後でも取り込まれる）。もし blume 入りの `pnpm-lock.yaml` が既にコミットされた状態から再開する場合は、`pnpm update blume` で lockfile を更新してからコミットすること。
+> 待てない場合の既知の回避策: `astro` / `@astrojs/mdx` / `@shikijs/twoslash` / `@tailwindcss/vite` / `@orama/orama` を blume と同じレンジで docs の依存に一時追加する（1.0.4 で削除）。
+> Task 1〜2 は 1.0.3 で一度実施済みで、ビルド以外は検証済み（`blume --version` 動作確認済み、ビルドのみ上記バグで失敗）。**Task 2 Step 5 以降のビルド成功を期待する記述は、blume 1.0.4+ がインストールされていることが前提。**
 
 ## Global Constraints
 
@@ -28,21 +29,21 @@
 
 ## 新旧対応の全体マップ
 
-| 現在（Starlight） | 移行後（blume） |
-| --- | --- |
-| `docs/astro.config.mjs` | `docs/blume.config.ts` |
-| `docs/src/content/docs/**` | `docs/content/**` |
-| `docs/src/content/docs/ja/**` | `docs/content/ja/**` |
-| `docs/src/assets/*.svg` | `docs/public/*.svg` |
-| `docs/src/styles/custom.css` | 廃止（Task 8 の目視確認で表が崩れる場合のみ `docs/theme.css` を追加） |
-| `docs/src/content.config.ts` | 廃止（blume が内部処理） |
-| `docs/tsconfig.json` | 廃止（blume が `.blume/` 内で管理） |
-| astro.config の `sidebar` + `translations` | フォルダ `meta.ts` / `meta.$.ts` + ページ frontmatter `sidebar.order` |
-| `withastro/action` | `pnpm --filter docs build` + Pages 公式アクション |
+| 現在（Starlight）                          | 移行後（blume）                                                                |
+| ------------------------------------------ | ------------------------------------------------------------------------------ |
+| `docs/astro.config.mjs`                    | `docs/blume.config.ts`                                                         |
+| `docs/src/content/docs/**`                 | `docs/content/**`                                                              |
+| `docs/src/content/docs/ja/**`              | `docs/content/ja/**`                                                           |
+| `docs/src/assets/*.svg`                    | `docs/public/*.svg`                                                            |
+| `docs/src/styles/custom.css`               | 廃止（Task 8 の目視確認で表が崩れる場合のみ `docs/theme.css` を追加）          |
+| `docs/src/content.config.ts`               | 廃止（blume が内部処理）                                                       |
+| `docs/tsconfig.json`                       | blume 推奨内容に更新（`blume check` が authored ファイルを検査するために必要） |
+| astro.config の `sidebar` + `translations` | フォルダ `meta.ts` / `meta.$.ts` + ページ frontmatter `sidebar.order`          |
+| `withastro/action`                         | `pnpm --filter docs build` + Pages 公式アクション                              |
 
 サイドバーの最終形（en。ja は同構造で `meta.ts` のラベルが翻訳される）:
 
-```
+```text
 (index)               ← content/index.mdx
 Installing            ← ページ, sidebar.order: 1
 Usage                 ← ページ, sidebar.order: 2
@@ -61,11 +62,13 @@ Types                 ← グループ, meta.ts order: 4
 ### Task 1: 依存関係を blume に切り替える
 
 **Files:**
+
 - Modify: `pnpm-workspace.yaml`
 - Modify: `docs/package.json`
 - Modify: `.gitignore`
 
 **Interfaces:**
+
 - Produces: `pnpm --filter docs exec blume <cmd>` が動く状態（以降の全タスクが依存）
 
 - [ ] **Step 1: `pnpm-workspace.yaml` の catalog を更新**
@@ -130,7 +133,7 @@ catalog:
 
 `.astro/` の行の直後に追加:
 
-```
+```text
 .astro/
 .blume/
 ```
@@ -159,13 +162,15 @@ git commit -m "docs: replace starlight deps with blume"
 ### Task 2: blume.config.ts とアセットを作成し初回ビルドを通す
 
 **Files:**
+
 - Create: `docs/blume.config.ts`
 - Create: `docs/content/index.mdx`
 - Move: `docs/src/assets/light-logo.svg` → `docs/public/light-logo.svg`
 - Move: `docs/src/assets/dark-logo.svg` → `docs/public/dark-logo.svg`
-- Delete: `docs/tsconfig.json`
+- Modify: `docs/tsconfig.json`
 
 **Interfaces:**
+
 - Produces: `pnpm --filter docs build` が成功する blume プロジェクトの骨格。`content/` 直下が以降のタスクのコンテンツ配置先。
 
 - [ ] **Step 1: ロゴを public/ へ移動**
@@ -247,13 +252,20 @@ seo:
 
 注意: blume のアイコンは Lucide 名（kebab-case）。Starlight の `document` → `file-text`、`seti:typescript` → `code` に置換している。`Card`/`CardGroup` は組み込みで import 不要。内部リンクは `/installing` のように base 抜きで書く（blume が `deployment.base` を付けて書き換える）。
 
-- [ ] **Step 4: 旧 tsconfig を削除**
+- [ ] **Step 4: tsconfig を blume 推奨内容に更新**
 
-```bash
-git rm docs/tsconfig.json
+`docs/tsconfig.json` を全文この内容にする（blume CLI リファレンス記載の推奨構成。プロジェクトルートの tsconfig がないと `blume check` は生成ランタイムしか検査しない）:
+
+```json
+{
+  "extends": "astro/tsconfigs/strict",
+  "include": [".blume/.astro/types.d.ts", ".blume/src/env.d.ts", "**/*"]
+}
 ```
 
 - [ ] **Step 5: ビルド確認**
+
+前提: blume 1.0.4+（isolated linker 修正版）がインストールされていること（冒頭のステータス注記を参照。1.0.3 ではこのステップは既知のバグで失敗する）。
 
 Run: `pnpm --filter docs build`
 Expected: `[build] Complete!` とビルドサマリー（`Output static` / `Search orama` / `Sitemap yes`）が出て `docs/dist/` が生成される。旧 `docs/src/content/docs/**` はまだ残っているが、blume は `content/` しか見ないため干渉しない。
@@ -261,7 +273,7 @@ Expected: `[build] Complete!` とビルドサマリー（`Output static` / `Sear
 - [ ] **Step 6: コミット**
 
 ```bash
-git add docs/blume.config.ts docs/content/index.mdx docs/public docs/src/assets docs/tsconfig.json
+git add -A docs
 git commit -m "docs: scaffold blume config, top page, and assets"
 ```
 
@@ -270,10 +282,12 @@ git commit -m "docs: scaffold blume config, top page, and assets"
 ### Task 3: 英語コンテンツを移行する
 
 **Files:**
+
 - Move+Modify: `docs/src/content/docs/**`（`ja/` 以外の全ファイル）→ `docs/content/**`
 - Create: `docs/content/meta-tags-properties/meta.ts`、`docs/content/open-graph/meta.$.ts`、`docs/content/json-ld/meta.$.ts`、`docs/content/json-ld/json-ld-properties/meta.$.ts`、`docs/content/types/meta.ts`、`docs/content/types/additional-types/meta.$.ts`
 
 **Interfaces:**
+
 - Consumes: Task 2 の `docs/content/` と `blume.config.ts`
 - Produces: 英語全ページのルート（`/installing`、`/meta-tags-properties/...` 等）。Task 4 の `ja/` ミラーはこの構造に対応させる。
 
@@ -469,10 +483,12 @@ git commit -m "docs: migrate English content to blume conventions"
 ### Task 4: 日本語コンテンツを移行する
 
 **Files:**
+
 - Move+Modify: `docs/src/content/docs/ja/**` → `docs/content/ja/**`
 - Create: `docs/content/ja/meta-tags-properties/meta.ts`、`docs/content/ja/types/meta.ts`
 
 **Interfaces:**
+
 - Consumes: Task 3 の en 構造（ja はそのミラー）。共有 `meta.$.ts`（Open Graph / JSON-LD / JSON-LD Properties / Additional types）は ja にも自動適用される。
 - Produces: `/ja/...` 全ルートと日本語サイドバー。
 
@@ -601,9 +617,11 @@ git commit -m "docs: migrate Japanese content to blume conventions"
 ### Task 5: Starlight の残骸を撤去する
 
 **Files:**
+
 - Delete: `docs/astro.config.mjs`、`docs/src/`（`content.config.ts`、`styles/custom.css`）、`docs/README.md`（空ファイル）
 
 **Interfaces:**
+
 - Consumes: Task 3・4 でコンテンツ移動が完了していること
 - Produces: blume のみで完結した `docs/` ワークスペース
 
@@ -642,9 +660,11 @@ git commit -m "docs: remove starlight scaffolding"
 ### Task 6: 新旧 URL を突合し redirects を確定する
 
 **Files:**
+
 - Modify: `docs/blume.config.ts`（差分があった場合のみ）
 
 **Interfaces:**
+
 - Consumes: Task 5 までの完成した `docs/dist/`
 - Produces: 旧 URL がすべて生きていることの保証（`redirects` 配列 or 差分ゼロの確認記録）
 
@@ -653,8 +673,11 @@ git commit -m "docs: remove starlight scaffolding"
 Run:
 
 ```bash
-curl -s https://oekazuma.github.io/svelte-meta-tags/sitemap-0.xml | grep -o '<loc>[^<]*</loc>' | sed -e 's/<\/\?loc>//g' -e 's|https://oekazuma.github.io/svelte-meta-tags||' -e 's|/$||' | sort > /tmp/claude/old-urls.txt
+mkdir -p /tmp/claude
+curl -s https://oekazuma.github.io/svelte-meta-tags/sitemap-0.xml | grep -o '<loc>[^<]*</loc>' | sed -e 's/<\/\?loc>//g' -e 's|https://oekazuma.github.io/svelte-meta-tags||' -e 's|/$||' -e 's|^$|/|' | sort > /tmp/claude/old-urls.txt
 ```
+
+（末尾の `s|^$|/|` はサイトルートを `/` に正規化する。新 URL 側と表現を揃えないと突合で偽差分が出る）
 
 （`sitemap-0.xml` が 404 の場合は `sitemap-index.xml` を見て実ファイル名を確認する）
 
@@ -663,10 +686,10 @@ curl -s https://oekazuma.github.io/svelte-meta-tags/sitemap-0.xml | grep -o '<lo
 Run:
 
 ```bash
-cd docs/dist && find . -name 'index.html' | sed -e 's|^\.||' -e 's|/index.html$||' -e 's|^$|/|' | sed 's|^/svelte-meta-tags||' | sort > /tmp/claude/new-urls.txt && cd -
+cd docs/dist && find . -name 'index.html' | sed -e 's|^\.||' -e 's|/index.html$||' -e 's|^/svelte-meta-tags||' -e 's|^$|/|' | sort > /tmp/claude/new-urls.txt && cd -
 ```
 
-（`deployment.base` 設定により dist 直下が `svelte-meta-tags/` 配下になっている場合は sed が吸収する。構造が違ったら実際の dist を見て調整する）
+（base の除去（`s|^/svelte-meta-tags||`）を先に行ってから空文字列を `/` に正規化する順序が重要。`deployment.base` 設定により dist 直下が `svelte-meta-tags/` 配下になっている場合もこの sed が吸収する。構造が違ったら実際の dist を見て調整する）
 
 - [ ] **Step 3: 突合**
 
@@ -676,9 +699,7 @@ Expected: **空**（旧 URL がすべて新ビルドに存在する）。
 出力がある場合、それが「旧にあって新にない」URL。各行について `docs/blume.config.ts` に redirect を追加する:
 
 ```ts
-redirects: [
-  { from: '/old-path', to: '/new-path' }
-]
+redirects: [{ from: '/old-path', to: '/new-path' }];
 ```
 
 追加後 `pnpm --filter docs build` を再実行し、Step 2〜3 を繰り返して空になることを確認する。ビルドサマリーの `Redirects` 行の件数が追加分と一致すること。
@@ -695,9 +716,11 @@ git commit -m "docs: add redirects for moved pages"
 ### Task 7: GitHub Pages デプロイワークフローを更新する
 
 **Files:**
+
 - Modify: `.github/workflows/deploy-docs.yml`
 
 **Interfaces:**
+
 - Consumes: Task 1 の `docs` build スクリプト（`blume build`）、既存 composite action `.github/workflows/setup-node/`（Node/pnpm をルート `package.json` から解決）
 - Produces: main マージ時に blume ビルドを GitHub Pages へ公開するワークフロー
 
@@ -768,12 +791,16 @@ git commit -m "ci: build docs with blume for GitHub Pages"
 ### Task 8: 最終検証（プレビュー目視）
 
 **Files:**
+
 - Create（必要時のみ）: `docs/theme.css`
 
 **Interfaces:**
+
 - Consumes: 全タスクの成果物
 
 - [ ] **Step 1: フルチェーンを一括実行**
+
+前提: blume 1.0.4+（isolated linker 修正版）がインストールされていること（冒頭のステータス注記を参照）。
 
 Run: `pnpm install && pnpm lint && pnpm --filter docs check && pnpm --filter docs build && pnpm --filter docs exec blume validate && pnpm --filter docs exec blume doctor`
 Expected: すべて成功。ビルドサマリーで `Sitemap yes` / `LLM files yes` / `Search orama` を確認。

--- a/superpowers/specs/2026-07-15-blume-migration-design.md
+++ b/superpowers/specs/2026-07-15-blume-migration-design.md
@@ -23,27 +23,30 @@ docs/
   blume.config.ts
   package.json
   content/
-    meta.ts                    (ルートの並び順: installing → usage → meta-tags-properties → open-graph → json-ld → deep-merge-function → types → migration-guide)
     index.mdx                  → /
     installing.mdx             → /installing
     usage.mdx                  → /usage
-    meta-tags-properties/      → /meta-tags-properties/…   (index + 7ページ + meta.ts)
-    open-graph/                → /open-graph/…             (index + 5ページ + meta.ts)
-    json-ld/                   → /json-ld/…
-      json-ld-properties/      (index + 7ページ + meta.ts)
     deep-merge-function.md     → /deep-merge-function
+    migration-guide.md         → /migration-guide
+    meta-tags-properties/      → /meta-tags-properties/…   (index + 7ページ + meta.ts)
+    open-graph/                → /open-graph/…             (index + 5ページ + meta.$.ts)
+    json-ld/                   → /json-ld/…                (index + meta.$.ts)
+      json-ld-properties/      (index + 7ページ + meta.$.ts)
     types/                     → /types/…                  (index なし・10ページ + meta.ts)
       additional-types/        (index + 12ページ + meta.ts)
-    migration-guide.md         → /migration-guide
     ja/                        (上記の完全ミラー + ロケール別 meta.ts)
   public/
-    favicon.svg
+    favicon.svg                (blume が自動検出。config に favicon 項目は存在しない)
     light-logo.svg
     dark-logo.svg
 ```
 
-- サイドバーはファイルシステムから自動生成する。グループのラベル・順序はフォルダごとの `meta.ts`（`defineMeta`）で指定する。
-- 日本語のグループラベル（インストール、使い方、MetaTags プロパティ、型定義、移行ガイド等 — 現在 `astro.config.mjs` の `translations` にあるもの）は `ja/` 側の同位置の `meta.ts` に移す。
+- サイドバーはファイルシステムから自動生成する。
+- **並び順**: blume の flat 表示（デフォルト）では「グループに属さないページは常に全グループの上」に表示される仕様のため、並びは「トップレベルページ4つ（Installing → Usage → Deep Merge function → Migration Guide）→ グループ4つ（MetaTags Properties → Open Graph → JSON-LD → Types）」とする（承認済み。現行サイトからの並び変更を受け入れる）。
+  - トップレベルページの順序は各ページの frontmatter `sidebar.order` で指定する。
+  - グループの順序は各フォルダの `meta.ts`（`defineMeta`）の `order` フィールドで指定する。
+  - コンテンツルート直下に置く `meta.ts` で最上位の並びを一括指定する方法は文書化されていないため使わない。
+- 日本語のグループラベル（MetaTags プロパティ、型定義等 — 現在 `astro.config.mjs` の `translations` にあるもの）は `ja/` 側の同位置の `meta.ts` に移す。日本語でもラベルが同一のグループ（Open Graph、JSON-LD）は `meta.$.ts`（全ロケール共有メタ）を使い、ja 側の重複ファイルを省く。
 - 日本語 URL は現行どおり `/ja/…` プレフィックス。未翻訳ページは en に自動フォールバックし、言語スイッチャーと `hreflang` は blume が自動生成する。
 - 既存の en/ja ミラー対応関係（どの en ページに ja 訳があるか）を移行で崩さない。
 
@@ -55,6 +58,8 @@ import { defineConfig } from 'blume';
 export default defineConfig({
   title: 'SvelteMetaTags',
   description: 'Svelte Meta Tags provides components designed to help you manage SEO for Svelte projects.',
+  content: { root: 'content' }, // デフォルトは 'docs'（docs/docs/ になってしまう）ため明示必須
+
   logo: {
     image: { light: '/light-logo.svg', dark: '/dark-logo.svg', alt: 'SvelteMetaTags' },
     text: '' // 現行の replacesTitle: true 相当（ロゴ単独表示）
@@ -103,7 +108,7 @@ export default defineConfig({
 ### docs/package.json
 
 - `dependencies`: `blume` のみ（`catalog:` 参照）。`pnpm-workspace.yaml` の catalog に `blume` を追加し、docs 専用だった `@astrojs/starlight` / `astro` / `@astrojs/check` / `sharp` を catalog から削除する（他ワークスペースで未使用であることを実装時に確認）。`minimumReleaseAge` フィールドは維持する。
-- `scripts`: `dev: blume dev` / `build: blume build` / `preview: blume preview`。`check`（現 `astro check`）は blume に相当コマンドがないため削除する。ルートの `pnpm check` は `-r` 実行なので docs が抜けても他ワークスペースに影響しない。
+- `scripts`: `dev: blume dev` / `build: blume build` / `preview: blume preview` / `check: blume check`。`blume check` は `astro check` によるタイプチェックで、現行の `check` スクリプトの置き換えとしてそのまま機能する（ルートの `pnpm check` にも docs が残る）。
 
 ### .github/workflows/deploy-docs.yml
 
@@ -115,10 +120,12 @@ export default defineConfig({
 ## 検証（成功基準）
 
 1. `pnpm install` が通る（catalog 変更後）。
-2. `pnpm --filter docs build` が成功し `docs/dist/` が生成される。
-3. `blume preview` で en/ja 両ロケールについて、全ページの表示・サイドバー構成（グループ名・順序が現行と一致）・言語スイッチャー・検索の動作を確認する。
-4. `pnpm lint`（prettier + eslint）が通る。
-5. ビルドサマリーで sitemap / llms.txt / redirects の出力を確認する。
+2. `pnpm --filter docs build` が成功し `docs/dist/` が生成される（CI では `blume build --strict` の採用を検討）。
+3. `pnpm --filter docs check`（`blume check`）が通る。
+4. `blume validate` でコンテンツ全体のリンク切れがないことを確認する。`blume doctor` で設定・コンテンツの診断が通る。
+5. `blume preview` で en/ja 両ロケールについて、全ページの表示・サイドバー構成（本スペックの並び順どおり）・言語スイッチャー・検索の動作を確認する。
+6. `pnpm lint`（prettier + eslint）が通る。
+7. ビルドサマリーで sitemap / llms.txt / redirects の出力を確認する。
 
 ## リスク
 

--- a/superpowers/specs/2026-07-15-blume-migration-design.md
+++ b/superpowers/specs/2026-07-15-blume-migration-design.md
@@ -18,7 +18,7 @@
 
 `docs/src/content/docs/` → `docs/content/` へ移動し、以下の構成にする。単独ページしか持たない現在のグループ（Installing / Usage / Deep Merge function / Migration Guide）はトップレベルページにフラット化する。
 
-```
+```text
 docs/
   blume.config.ts
   package.json
@@ -76,9 +76,7 @@ export default defineConfig({
     site: 'https://oekazuma.github.io',
     base: '/svelte-meta-tags'
   },
-  redirects: [
-    /* 移行で URL が変わったページ分をここに列挙する（実装時に新旧対応表を作って確定） */
-  ]
+  redirects: [/* 移行で URL が変わったページ分をここに列挙する（実装時に新旧対応表を作って確定） */]
 });
 ```
 
@@ -90,14 +88,14 @@ export default defineConfig({
 
 全 Markdown/MDX（en 約40 + ja 約40ファイル）に以下を機械的に適用する。en/ja とも同一ルール。
 
-| Starlight | blume |
-| --- | --- |
-| frontmatter `title` / `description` / `sidebar.order` | そのまま互換（変換不要） |
+| Starlight                                                                                | blume                                                                    |
+| ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| frontmatter `title` / `description` / `sidebar.order`                                    | そのまま互換（変換不要）                                                 |
 | `head:` / `template: splash` / `hero:` / `editUrl` / `lastUpdated`（index.mdx のみ使用） | 削除。トップは通常ページ化し `Card` / `CardGroup` で主要セクションへ誘導 |
-| `import { Tabs, TabItem } from '@astrojs/starlight/components'` | import 削除。パッケージマネージャ切り替えは `CodeGroup` に置換 |
-| `Card` / `CardGrid` | 組み込みの `Card` / `CardGroup`（import 不要） |
-| `Aside` | `:::note` / `:::tip` / `:::caution` 記法 |
-| `LinkButton` | `Card` またはリンク付き段落 |
+| `import { Tabs, TabItem } from '@astrojs/starlight/components'`                          | import 削除。パッケージマネージャ切り替えは `CodeGroup` に置換           |
+| `Card` / `CardGrid`                                                                      | 組み込みの `Card` / `CardGroup`（import 不要）                           |
+| `Aside`                                                                                  | `:::note` / `:::tip` / `:::caution` 記法                                 |
+| `LinkButton`                                                                             | `Card` またはリンク付き段落                                              |
 
 撤去するファイル: `astro.config.mjs`、`src/content.config.ts`、`src/styles/custom.css`、`src/assets/`（ロゴ SVG は `public/` へ移動）。`tsconfig.json` は blume の推奨内容に合わせて更新する。
 

--- a/superpowers/specs/2026-07-15-blume-migration-design.md
+++ b/superpowers/specs/2026-07-15-blume-migration-design.md
@@ -1,0 +1,126 @@
+# docs/ を Starlight から blume へ移行する設計
+
+日付: 2026-07-15
+ステータス: 承認済み（ブレインストーミングセッションにて）
+
+## 目的
+
+`docs/` の Astro + Starlight 製ドキュメントサイトを [blume](https://github.com/haydenbleasel/blume)（v1.0.3、Astro ベースの markdown-first ドキュメントプラットフォーム）に置き換える。英語 + 日本語の2ロケール構成と GitHub Pages（`/svelte-meta-tags` サブパス）へのデプロイを維持する。
+
+## 決定事項
+
+- **アプローチ**: `docs/` ワークスペース内で丸ごと置き換え（1 PR で切り替え）。並行構築や eject 前提の構成は採らない。
+- **URL 構造**: blume の規約に合わせて再構成してよい。変更が生じた URL は `blume.config.ts` の `redirects` で旧 URL からリダイレクトする（静的ビルドではリダイレクトページとして出力される）。
+- **トップページ**: Starlight の splash テンプレート + hero は廃止し、通常のドキュメントページ（概要 + 主要セクションへの `Card` リンク）に簡素化する。
+- **changeset**: 不要（docs サイトのみの内部変更のため）。
+
+## コンテンツ構成
+
+`docs/src/content/docs/` → `docs/content/` へ移動し、以下の構成にする。単独ページしか持たない現在のグループ（Installing / Usage / Deep Merge function / Migration Guide）はトップレベルページにフラット化する。
+
+```
+docs/
+  blume.config.ts
+  package.json
+  content/
+    meta.ts                    (ルートの並び順: installing → usage → meta-tags-properties → open-graph → json-ld → deep-merge-function → types → migration-guide)
+    index.mdx                  → /
+    installing.mdx             → /installing
+    usage.mdx                  → /usage
+    meta-tags-properties/      → /meta-tags-properties/…   (index + 7ページ + meta.ts)
+    open-graph/                → /open-graph/…             (index + 5ページ + meta.ts)
+    json-ld/                   → /json-ld/…
+      json-ld-properties/      (index + 7ページ + meta.ts)
+    deep-merge-function.md     → /deep-merge-function
+    types/                     → /types/…                  (index なし・10ページ + meta.ts)
+      additional-types/        (index + 12ページ + meta.ts)
+    migration-guide.md         → /migration-guide
+    ja/                        (上記の完全ミラー + ロケール別 meta.ts)
+  public/
+    favicon.svg
+    light-logo.svg
+    dark-logo.svg
+```
+
+- サイドバーはファイルシステムから自動生成する。グループのラベル・順序はフォルダごとの `meta.ts`（`defineMeta`）で指定する。
+- 日本語のグループラベル（インストール、使い方、MetaTags プロパティ、型定義、移行ガイド等 — 現在 `astro.config.mjs` の `translations` にあるもの）は `ja/` 側の同位置の `meta.ts` に移す。
+- 日本語 URL は現行どおり `/ja/…` プレフィックス。未翻訳ページは en に自動フォールバックし、言語スイッチャーと `hreflang` は blume が自動生成する。
+- 既存の en/ja ミラー対応関係（どの en ページに ja 訳があるか）を移行で崩さない。
+
+## blume.config.ts
+
+```ts
+import { defineConfig } from 'blume';
+
+export default defineConfig({
+  title: 'SvelteMetaTags',
+  description: 'Svelte Meta Tags provides components designed to help you manage SEO for Svelte projects.',
+  logo: {
+    image: { light: '/light-logo.svg', dark: '/dark-logo.svg', alt: 'SvelteMetaTags' },
+    text: '' // 現行の replacesTitle: true 相当（ロゴ単独表示）
+  },
+  github: { owner: 'oekazuma', repo: 'svelte-meta-tags', dir: 'docs' },
+  i18n: {
+    defaultLocale: 'en',
+    locales: [
+      { code: 'en', label: 'English' },
+      { code: 'ja', label: '日本語' }
+    ]
+  },
+  deployment: {
+    site: 'https://oekazuma.github.io',
+    base: '/svelte-meta-tags'
+  },
+  redirects: [
+    /* 移行で URL が変わったページ分をここに列挙する（実装時に新旧対応表を作って確定） */
+  ]
+});
+```
+
+- 検索はデフォルトの Orama ローカル検索を使う（設定不要、ロケール対応）。
+- `llms.txt` / `llms-full.txt` / sitemap は blume が自動生成する。
+- Ask AI 等のサーバー機能は使わない（GitHub Pages は静的ホスティングのため）。
+
+## コンテンツ変換ルール
+
+全 Markdown/MDX（en 約40 + ja 約40ファイル）に以下を機械的に適用する。en/ja とも同一ルール。
+
+| Starlight | blume |
+| --- | --- |
+| frontmatter `title` / `description` / `sidebar.order` | そのまま互換（変換不要） |
+| `head:` / `template: splash` / `hero:` / `editUrl` / `lastUpdated`（index.mdx のみ使用） | 削除。トップは通常ページ化し `Card` / `CardGroup` で主要セクションへ誘導 |
+| `import { Tabs, TabItem } from '@astrojs/starlight/components'` | import 削除。パッケージマネージャ切り替えは `CodeGroup` に置換 |
+| `Card` / `CardGrid` | 組み込みの `Card` / `CardGroup`（import 不要） |
+| `Aside` | `:::note` / `:::tip` / `:::caution` 記法 |
+| `LinkButton` | `Card` またはリンク付き段落 |
+
+撤去するファイル: `astro.config.mjs`、`src/content.config.ts`、`src/styles/custom.css`、`src/assets/`（ロゴ SVG は `public/` へ移動）。`tsconfig.json` は blume の推奨内容に合わせて更新する。
+
+`custom.css` の内容は移行時に精査し、ブランドカラー等の必要なものだけ blume の `theme.css`（Tailwind v4 テーマトークン）へ移植する。不要であれば持ち込まない。
+
+## パッケージと CI
+
+### docs/package.json
+
+- `dependencies`: `blume` のみ（`catalog:` 参照）。`pnpm-workspace.yaml` の catalog に `blume` を追加し、docs 専用だった `@astrojs/starlight` / `astro` / `@astrojs/check` / `sharp` を catalog から削除する（他ワークスペースで未使用であることを実装時に確認）。`minimumReleaseAge` フィールドは維持する。
+- `scripts`: `dev: blume dev` / `build: blume build` / `preview: blume preview`。`check`（現 `astro check`）は blume に相当コマンドがないため削除する。ルートの `pnpm check` は `-r` 実行なので docs が抜けても他ワークスペースに影響しない。
+
+### .github/workflows/deploy-docs.yml
+
+- `withastro/action` を撤去し、以下の構成に置き換える: checkout → 既存 composite action `.github/workflows/setup-node/` → `pnpm install` → `pnpm --filter docs build` → `actions/configure-pages` → `actions/upload-pages-artifact`（path: `docs/dist`）→ `actions/deploy-pages`。
+- すべてのアクションは SHA ピン留め + `# vX.Y.Z` コメントのスタイルを維持する。
+- Node / pnpm のバージョンは従来どおりルート `package.json` から解決する（Node 24.17 は blume の要件 22.12+ を満たす）。
+- `paths: docs/**` トリガーは変更しない。
+
+## 検証（成功基準）
+
+1. `pnpm install` が通る（catalog 変更後）。
+2. `pnpm --filter docs build` が成功し `docs/dist/` が生成される。
+3. `blume preview` で en/ja 両ロケールについて、全ページの表示・サイドバー構成（グループ名・順序が現行と一致）・言語スイッチャー・検索の動作を確認する。
+4. `pnpm lint`（prettier + eslint）が通る。
+5. ビルドサマリーで sitemap / llms.txt / redirects の出力を確認する。
+
+## リスク
+
+- blume は v1.0.3（2026年7月リリース）と非常に新しく、破壊的変更や未成熟な部分に当たる可能性がある。問題が解消できない場合は `.blume/` の eject（標準 Astro プロジェクト化）という逃げ道がある。
+- `blume build` の出力（trailing slash の扱い等）が Starlight と異なる場合、想定外の URL 変化が起きうる。実装時にビルド出力の実 URL を新旧対応表と突き合わせて確認する。


### PR DESCRIPTION
## Summary

docs/ サイトを Astro + Starlight から [blume](https://github.com/haydenbleasel/blume) へ移行するための設計スペックと実装計画を追加します。**このPRはドキュメントのみで、実装は含みません。**

- `superpowers/specs/2026-07-15-blume-migration-design.md` — 移行設計（blume v1.0.3 の同梱ドキュメント・型定義と突き合わせて検証済み）
- `superpowers/plans/2026-07-15-blume-migration.md` — 8タスクの実装計画（コマンド・ファイル内容・検証手順つき）

## 実装が保留になっている理由

blume 1.0.3 には pnpm の隔離型 node_modules で `.blume/` ランタイムが `astro` を解決できないバグがあります。修正は upstream の main にマージ済みですが未リリースのため、blume 1.0.4+ のリリース後に計画の Task 2 から再開します（詳細と回避策はプラン冒頭のステータス注記を参照）。

Task 1〜2 の実装コミットはローカルの `docs/migrate-to-blume` ブランチに保全してあります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a detailed plan and design specification for migrating the documentation site to Blume v1.0.3.
  * Documented English and Japanese localization, sidebar ordering, content conversion, URL redirects, and GitHub Pages deployment requirements.
  * Included validation steps, migration constraints, known runtime risks, and upgrade conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->