### PR TITLE
docs: restructure Migration Guide headings for clarity

### DIFF
--- a/docs/content/ja/migration-guide.md
+++ b/docs/content/ja/migration-guide.md
@@ -12,10 +12,13 @@ sidebar:
 - `schema-dts` v2 には独自の破壊的な型変更があります（`Role` の非再帰化、コアの DataType としての `Quantity`、schema.org 以外の型エクスポートのリネームなど）。詳細は [schema-dts v2.0.0 のリリースノート](https://github.com/google/schema-dts/releases/tag/v2.0.0) を参照してください。
 - `schema-dts` v2 は `schema-dts-lib` に依存しており、これは `typescript >=4.9.5` をピア依存関係として宣言しています。厳格なピア依存関係の検証を行う環境（例: pnpm の `strict-peer-dependencies=true`）では、`typescript` を明示的に追加する必要がある場合があります。
 
-`twitter.handle` は `twitter.creator` に名前が変更されました。
+## v4
+
+### `twitter.handle` を `twitter.creator` にリネーム
+
 この変更は実際のプロパティ名と一致します。
 
-## v3
+**変更前 (v3)**
 
 ```svelte
 <MetaTags
@@ -31,7 +34,7 @@ sidebar:
 />
 ```
 
-## v4
+**変更後 (v4)**
 
 ```svelte
 <MetaTags
@@ -47,13 +50,15 @@ sidebar:
 />
 ```
 
-2つ以上のオブジェクトの列挙可能なプロパティを深くマージする関数`deepMerge`を追加しました・
+### `deepMerge` を追加
 
-ライブラリが提供する`deepMerge`関数の使用は必須ではないため、好きなものを使い続けることができますが、依存関係が減るためおすすめします。
+`deepMerge`は、2つ以上のオブジェクトの列挙可能なプロパティを深くマージする関数です。
+
+ライブラリが提供する `deepMerge` 関数の使用は必須ではないため、好きなものを使い続けることができますが、依存関係が減るためおすすめします。
 
 使用方法の詳細については [例](https://github.com/oekazuma/svelte-meta-tags/tree/main/example/src/routes) を参照してください。
 
-## v3
+**変更前 (v3)**
 
 `+layout.svelte`
 
@@ -61,7 +66,7 @@ sidebar:
 <script>
   import { MetaTags } from 'svelte-meta-tags';
   import { page } from '$app/stores';
-  import extend from 'just-extend'; //lodash.merge、deepmerge、just-extendなどのオブジェクトのディープマージを可能にする関数を使用してください
+  import extend from 'just-extend'; // lodash.merge、deepmerge、just-extendなどのオブジェクトのディープマージを可能にする関数を使用してください
 
   export let data;
 
@@ -73,7 +78,7 @@ sidebar:
 <slot />
 ```
 
-## v4
+**変更後 (v4)**
 
 `+layout.svelte`
 

--- a/docs/content/migration-guide.md
+++ b/docs/content/migration-guide.md
@@ -12,10 +12,13 @@ sidebar:
 - `schema-dts` v2 has its own breaking type changes (non-recursive `Role`, `Quantity` as a core DataType, renamed non-schema.org type exports) — see the [schema-dts v2.0.0 release notes](https://github.com/google/schema-dts/releases/tag/v2.0.0).
 - `schema-dts` v2 depends on `schema-dts-lib`, which declares `typescript >=4.9.5` as a peer dependency. Under strict peer-dependency enforcement (e.g. pnpm's `strict-peer-dependencies=true`), you may need to add `typescript` explicitly.
 
-`twitter.handle` has been renamed `twitter.creator`
+## v4
+
+### `twitter.handle` renamed to `twitter.creator`
+
 This change aligns with the actual property name.
 
-## v3
+**Before (v3)**
 
 ```svelte
 <MetaTags
@@ -31,7 +34,7 @@ This change aligns with the actual property name.
 />
 ```
 
-## v4
+**After (v4)**
 
 ```svelte
 <MetaTags
@@ -47,13 +50,15 @@ This change aligns with the actual property name.
 />
 ```
 
-Add `deepMerge`, a function that deeply merges the enumerable properties of two or more objects.
+### Added `deepMerge`
 
-The use of the deepMerge function provided by this library is not mandatory, so you can continue to use whatever you like, but it is recommended because it reduces dependencies.
+`deepMerge` is a function that deeply merges the enumerable properties of two or more objects.
+
+Using the `deepMerge` function provided by this library is not mandatory, so you can continue to use whatever you like, but it is recommended because it reduces dependencies.
 
 See [Example](https://github.com/oekazuma/svelte-meta-tags/tree/main/example/src/routes) for details on how to use it.
 
-## v3
+**Before (v3)**
 
 `+layout.svelte`
 
@@ -73,7 +78,7 @@ See [Example](https://github.com/oekazuma/svelte-meta-tags/tree/main/example/src
 <slot />
 ```
 
-## v4
+**After (v4)**
 
 `+layout.svelte`
 


### PR DESCRIPTION
## Summary

Migration Guideの見出し構造が分かりにくいという指摘があったため整理しました。

**Before:** `## v5` の直後に見出しなしの説明文が挟まり、その後 `## v3` → `## v4` → (deepMergeの説明) → `## v3` → `## v4` と、同じ見出しテキストが2回ずつ繰り返される構造になっていました。

**After:** バージョンごとに1つのトップレベル見出し(`## v5`, `## v4`)にまとめ、v4内の2つの変更点(`twitter.creator`へのリネーム、`deepMerge`の追加)をH3見出しで分離。コード比較は「Before (v3)」/「After (v4)」の明示ラベル付きにしました(英語版・日本語版とも)。

## Test plan

- [x] `pnpm --filter docs build` 成功
- [x] `pnpm --filter docs exec blume validate` — リンク切れなし
- [x] `pnpm lint` 成功
- [x] レンダリングされた見出し階層を確認(`h2: v5, v4` → `h3: twitter.handle renamed..., Added deepMerge`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the v3-to-v4 migration from `twitter.handle` to `twitter.creator`.
  - Updated Twitter metadata examples to use the new property name.
  - Added guidance and examples for the new `deepMerge` utility.
  - Refreshed migration examples to reflect current SvelteKit patterns and clearly distinguish before-and-after code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->