### PR TITLE
test: fix e2e gaps and add coverage for body JSON-LD, robots, video.other

### DIFF
--- a/tests/svelte-5/src/routes/additionalRobots/+page.svelte
+++ b/tests/svelte-5/src/routes/additionalRobots/+page.svelte
@@ -9,6 +9,7 @@
     notranslate: true,
     noimageindex: true,
     noarchive: true,
+    unavailableAfter: '2030-12-31',
     maxSnippet: -1,
     maxImagePreview: 'none',
     maxVideoPreview: -1

--- a/tests/svelte-5/src/routes/jsonldEmpty/+page.svelte
+++ b/tests/svelte-5/src/routes/jsonldEmpty/+page.svelte
@@ -1,0 +1,9 @@
+<script>
+  import { JsonLd, MetaTags } from 'svelte-meta-tags';
+</script>
+
+<MetaTags title="JSON-LD Empty Page Title | Svelte Meta Tags" />
+
+<JsonLd />
+
+<h1>JSON-LD Empty SEO</h1>

--- a/tests/svelte-5/src/routes/videoOther/+page.svelte
+++ b/tests/svelte-5/src/routes/videoOther/+page.svelte
@@ -1,0 +1,19 @@
+<script>
+  import { MetaTags } from 'svelte-meta-tags';
+</script>
+
+<MetaTags
+  title="Video Other Page Title | Svelte Meta Tags"
+  description="Description of video other page"
+  openGraph={{
+    title: 'Open Graph Video Other Title',
+    url: 'https://www.example.com/videos/video-other-title',
+    type: 'video.other',
+    video: {
+      directors: ['https://www.example.com/directors/@firstnameA-lastnameA'],
+      series: 'The Example Series'
+    }
+  }}
+/>
+
+<h1>Video Other SEO</h1>

--- a/tests/svelte-5/tests/additionalRobots.test.ts
+++ b/tests/svelte-5/tests/additionalRobots.test.ts
@@ -6,6 +6,6 @@ test('Additional Robots props SEO applied correctly', async ({ page }) => {
   await expect(page.locator('h1')).toContainText('Robots props SEO');
   await expect(page.locator('head meta[name="robots"]')).toHaveAttribute(
     'content',
-    'index,follow,nosnippet,max-snippet:-1,max-image-preview:none,noarchive,noimageindex,max-video-preview:-1,notranslate'
+    'index,follow,nosnippet,max-snippet:-1,max-image-preview:none,noarchive,unavailable_after:2030-12-31,noimageindex,max-video-preview:-1,notranslate'
   );
 });

--- a/tests/svelte-5/tests/jsonLdBody.test.ts
+++ b/tests/svelte-5/tests/jsonLdBody.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 
-test('JSON-LD Head SEO loads correctly', async ({ page }) => {
+test('JSON-LD Body SEO loads correctly', async ({ page }) => {
   await page.goto('/jsonldBody', { waitUntil: 'domcontentloaded' });
   await expect(page).toHaveTitle('JSON-LD Body Page Title | Svelte Meta Tags');
   await expect(page.locator('h1')).toContainText('JSON-LD Body SEO');
@@ -9,8 +9,9 @@ test('JSON-LD Head SEO loads correctly', async ({ page }) => {
     'Description of JSON-LD Body page'
   );
   await expect(page.locator('head meta[name="robots"]')).toHaveAttribute('content', 'index,follow');
+  await expect(page.locator('head script[type="application/ld+json"]')).toHaveCount(0);
   const jsonLd = await page
-    .locator('script[type="application/ld+json"]')
+    .locator('body script[type="application/ld+json"]')
     .evaluateAll((list) => list.map((element) => element.textContent));
   expect(jsonLd[0]).toEqual(
     '{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Books","item":"https://example.com/books"},{"@type":"ListItem","position":2,"name":"Science Fiction","item":"https://example.com/books/sciencefiction"},{"@type":"ListItem","position":3,"name":"Award Winners"}]}'

--- a/tests/svelte-5/tests/jsonLdEmpty.test.ts
+++ b/tests/svelte-5/tests/jsonLdEmpty.test.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+
+test('JSON-LD is not rendered when schema is omitted', async ({ page }) => {
+  await page.goto('/jsonldEmpty', { waitUntil: 'domcontentloaded' });
+  await expect(page).toHaveTitle('JSON-LD Empty Page Title | Svelte Meta Tags');
+  await expect(page.locator('h1')).toContainText('JSON-LD Empty SEO');
+  await expect(page.locator('script[type="application/ld+json"]')).toHaveCount(0);
+});

--- a/tests/svelte-5/tests/normal.test.ts
+++ b/tests/svelte-5/tests/normal.test.ts
@@ -63,7 +63,6 @@ test('Normal SEO loads correctly', async ({ page, baseURL }) => {
   await expect(page.locator('head meta[name="twitter:card"]')).toHaveAttribute('content', 'summary_large_image');
   await expect(page.locator('head meta[name="twitter:site"]')).toHaveAttribute('content', '@site');
   await expect(page.locator('head meta[name="twitter:creator"]')).toHaveAttribute('content', '@handle');
-  await expect(page.locator('head meta[name="twitter:creator"]')).toHaveAttribute('content', '@handle');
   await expect(page.locator('head meta[name="twitter:title"]')).toHaveAttribute('content', 'Normal | Svelte Meta Tags');
   await expect(page.locator('head meta[name="twitter:description"]')).toHaveAttribute('content', 'Description');
   await expect(page.locator('head meta[name="twitter:image"]')).toHaveAttribute(

--- a/tests/svelte-5/tests/videoOther.test.ts
+++ b/tests/svelte-5/tests/videoOther.test.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test';
+
+test('Video Other SEO loads correctly', async ({ page }) => {
+  await page.goto('/videoOther', { waitUntil: 'domcontentloaded' });
+  await expect(page).toHaveTitle('Video Other Page Title | Svelte Meta Tags');
+  await expect(page.locator('h1')).toContainText('Video Other SEO');
+  await expect(page.locator('head meta[property="og:type"]')).toHaveAttribute('content', 'video.other');
+  await expect(page.locator('head meta[property="video:director"]')).toHaveAttribute(
+    'content',
+    'https://www.example.com/directors/@firstnameA-lastnameA'
+  );
+  await expect(page.locator('head meta[property="video:series"]')).toHaveAttribute('content', 'The Example Series');
+  await expect(page.locator('head meta[property="og:title"]')).toHaveAttribute(
+    'content',
+    'Open Graph Video Other Title'
+  );
+});


### PR DESCRIPTION
## Summary
- `jsonldBody` テストがテスト名・locator ともに head テストのコピペで、`output=\"body\"` が実際に body に描画されることを検証していなかったため修正
- `normal.test.ts` の重複アサーションを削除
- `additionalRobotsProps.unavailableAfter` のカバレッジを追加
- `openGraph.type: 'video.other'` および `video:series` のカバレッジを追加(新規ルート `videoOther`)
- `JsonLd` の schema 未指定時に何も描画しないことのカバレッジを追加(新規ルート `jsonldEmpty`)

## Test plan
- [x] `pnpm --filter svelte-5 exec playwright test --project=chromium` 全 pass(既存 20 + 新規 2 ファイル)
- [x] `pnpm lint` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the `/improve` skill (plans/001-e2e-test-gaps.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added coverage for pages with empty JSON-LD data and additional video metadata.
  * Added support coverage for the `unavailable_after` robots directive.
* **Bug Fixes**
  * Corrected JSON-LD placement expectations so structured data is verified in the page body.
  * Removed an outdated Twitter creator metadata assertion.
* **Tests**
  * Expanded end-to-end validation for JSON-LD, video Open Graph metadata, and robots directives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->