### PR TITLE
fix: harden deepMerge against __proto__/constructor/prototype source keys

### DIFF
--- a/.changeset/deepmerge-proto-hardening.md
+++ b/.changeset/deepmerge-proto-hardening.md
@@ -1,0 +1,5 @@
+---
+'svelte-meta-tags': patch
+---
+
+fix: harden `deepMerge` against `__proto__` / `constructor` / `prototype` keys in the source object

--- a/packages/svelte-meta-tags/src/lib/deepMerge.ts
+++ b/packages/svelte-meta-tags/src/lib/deepMerge.ts
@@ -8,6 +8,8 @@ export const deepMerge = <X extends Record<string | symbol | number, any>>(
   const result: Record<string | symbol | number, any> = { ...target };
 
   for (const [key, value] of Object.entries(source)) {
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue;
+
     const targetValue = target[key];
 
     if (targetValue instanceof Date || typeof targetValue === 'function') {

--- a/packages/svelte-meta-tags/tests/deepMerge/deepMerge.test.ts
+++ b/packages/svelte-meta-tags/tests/deepMerge/deepMerge.test.ts
@@ -118,4 +118,56 @@ describe('deepMerge functionality', () => {
     const result = deepMerge(undefined, null);
     expect(result).toEqual({});
   });
+
+  test('target Date wins over source value at the same key', () => {
+    const date = new Date('2020-01-01');
+    const result = deepMerge({ a: date }, { a: 5 });
+    expect(result.a).toEqual(date);
+  });
+
+  test('target function wins over source value at the same key', () => {
+    const func = () => {};
+    const result = deepMerge({ a: func }, { a: 5 });
+    expect(result.a).toBe(func);
+  });
+
+  test('source Date wins when target value is a plain value', () => {
+    const date = new Date('2021-06-15');
+    const result = deepMerge({ a: 5 }, { a: date });
+    expect(result.a).toEqual(date);
+  });
+
+  test('source function wins when target value is a plain value', () => {
+    const func = () => {};
+    const result = deepMerge({ a: 5 }, { a: func });
+    expect(result.a).toBe(func);
+  });
+
+  test('undefined source value keeps the target value', () => {
+    const result = deepMerge({ a: 1, b: 2 }, { a: undefined });
+    expect(result).toEqual({ a: 1, b: 2 });
+  });
+
+  test('symbol-keyed source properties are not merged (characterization)', () => {
+    const sym = Symbol('meta');
+    const source: Record<string | symbol, unknown> = { a: 1 };
+    source[sym] = 'dropped';
+    const result = deepMerge({ b: 2 }, source);
+    expect(result).toEqual({ a: 1, b: 2 });
+    expect((result as Record<string | symbol, unknown>)[sym]).toBeUndefined();
+  });
+
+  test('__proto__ key from JSON-parsed source does not alter the result prototype', () => {
+    const source = JSON.parse('{"__proto__": {"polluted": true}, "a": 1}');
+    const result = deepMerge({ b: 2 }, source);
+    expect(result).toEqual({ a: 1, b: 2 });
+    expect((result as Record<string, unknown>).polluted).toBeUndefined();
+    expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+  });
+
+  test('constructor and prototype keys are skipped', () => {
+    const source = JSON.parse('{"constructor": {"x": 1}, "prototype": {"y": 2}, "a": 1}');
+    const result = deepMerge({ b: 2 }, source);
+    expect(result).toEqual({ a: 1, b: 2 });
+  });
 });


### PR DESCRIPTION
## Summary
- `deepMerge` の仕様の核心(同一キーで target の Date/関数が勝つこと、source の `undefined` が target を維持すること)を特性テストとして固定
- `JSON.parse` 由来の source に `__proto__` / `constructor` / `prototype` キーが含まれる場合に結果オブジェクトのプロトタイプが書き換わる問題を修正(該当キーをスキップ)

## Test plan
- [x] `pnpm --filter svelte-meta-tags test` 全 pass(30 tests)
- [x] `pnpm lint` exit 0
- [x] changeset 追加済み(patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the `/improve` skill (plans/002-deepmerge-tests-and-hardening.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened metadata merging against prototype-pollution risks involving unsafe object keys.
  * Preserved expected behavior when merging dates, functions, undefined values, and other special cases.
* **Tests**
  * Expanded coverage for merge precedence, special values, symbol keys, and security-related edge cases.
* **Release**
  * Prepared a patch release for the metadata package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->