### PR TITLE
fix: escape JSON-LD output so schema values cannot break out of the script tag

### DIFF
--- a/.changeset/jsonld-escape-lt.md
+++ b/.changeset/jsonld-escape-lt.md
@@ -1,0 +1,5 @@
+---
+'svelte-meta-tags': patch
+---
+
+fix: escape `<` as `<` in JSON-LD output so schema values containing `</script>` cannot break out of the script tag

--- a/.changeset/jsonld-escape-lt.md
+++ b/.changeset/jsonld-escape-lt.md
@@ -2,4 +2,4 @@
 'svelte-meta-tags': patch
 ---
 
-fix: escape `<` as `<` in JSON-LD output so schema values containing `</script>` cannot break out of the script tag
+fix: escape `<` as the JSON escape sequence `\u003c` in JSON-LD output so schema values containing `</script>` cannot break out of the script tag

--- a/packages/svelte-meta-tags/src/lib/JsonLd.svelte
+++ b/packages/svelte-meta-tags/src/lib/JsonLd.svelte
@@ -20,7 +20,7 @@
   };
 
   let json = $derived(
-    `${'<scri' + 'pt type="application/ld+json">'}${JSON.stringify(createSchema(schema))}${'</scri' + 'pt>'}`
+    `${'<scri' + 'pt type="application/ld+json">'}${JSON.stringify(createSchema(schema)).replace(/</g, '\\u003c')}${'</scri' + 'pt>'}`
   );
 </script>
 

--- a/packages/svelte-meta-tags/src/lib/JsonLd.svelte
+++ b/packages/svelte-meta-tags/src/lib/JsonLd.svelte
@@ -19,9 +19,9 @@
       : addContext(schema as OmitContext<WithContext<Thing>>);
   };
 
-  let json = $derived(
-    `${'<scri' + 'pt type="application/ld+json">'}${JSON.stringify(createSchema(schema)).replace(/</g, '\\u003c')}${'</scri' + 'pt>'}`
-  );
+  let escapedJson = $derived(JSON.stringify(createSchema(schema)).replace(/</g, '\\u003c'));
+
+  let json = $derived(`${'<scri' + 'pt type="application/ld+json">'}${escapedJson}${'</scri' + 'pt>'}`);
 </script>
 
 <svelte:head>

--- a/tests/svelte-5/src/routes/jsonldEscape/+page.svelte
+++ b/tests/svelte-5/src/routes/jsonldEscape/+page.svelte
@@ -1,0 +1,13 @@
+<script>
+  import { JsonLd } from 'svelte-meta-tags';
+</script>
+
+<JsonLd
+  schema={{
+    '@type': 'Article',
+    headline: 'Escape </script> test <b>not bold</b>',
+    description: 'Values containing markup must stay inside the JSON-LD script tag'
+  }}
+/>
+
+<h1>JSON-LD Escape SEO</h1>

--- a/tests/svelte-5/tests/jsonLdEscape.test.ts
+++ b/tests/svelte-5/tests/jsonLdEscape.test.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+
+test('JSON-LD values containing </script> stay inside the script tag', async ({ page }) => {
+  await page.goto('/jsonldEscape', { waitUntil: 'domcontentloaded' });
+  await expect(page.locator('h1')).toContainText('JSON-LD Escape SEO');
+  const scripts = page.locator('head script[type="application/ld+json"]');
+  await expect(scripts).toHaveCount(1);
+  const raw = await scripts.first().textContent();
+  const parsed = JSON.parse(raw ?? '');
+  expect(parsed.headline).toBe('Escape </script> test <b>not bold</b>');
+  // タグ突破が起きていれば <b> 要素が DOM に生成されてしまう
+  await expect(page.locator('head b, body b')).toHaveCount(0);
+});


### PR DESCRIPTION
## Summary
`JsonLd` renders `JSON.stringify` output directly via `{@html}`. Since `JSON.stringify` does not escape `<`, a schema string value containing `</script>` closes the JSON-LD script tag early and the remainder is parsed as HTML. This PR escapes `<` as `<` in the JSON-LD output (a valid, semantically-neutral JSON escape — `JSON.parse` round-trips it back to `<`), which prevents the tag from being broken out of. The existing `'<scri' + 'pt'` string-splitting trick (already documented in AGENTS.md) is preserved unchanged.

## Test plan
- [x] New e2e test reproduces the issue (2 `<script type="application/ld+json">` elements were produced before the fix) and confirms exactly 1 after the fix, with a `JSON.parse` round-trip check and a check for no injected `<b>` element
- [x] All existing JSON-LD e2e tests pass unchanged
- [x] `pnpm --filter svelte-meta-tags check` exit 0
- [x] `pnpm lint` exit 0
- [x] changeset added (patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the `/improve` skill (plans/003-jsonld-script-escape.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * JSON-LD content now safely escapes `<` characters, preventing embedded values such as `</script>` from breaking out of the metadata script tag.

* **Tests**
  * Added coverage confirming JSON-LD remains valid and markup-sensitive content stays safely contained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->