### PR TITLE
fix: titleTemplate replacement-pattern handling and fb:app_id guard

### DIFF
--- a/.changeset/metatags-small-fixes.md
+++ b/.changeset/metatags-small-fixes.md
@@ -1,0 +1,5 @@
+---
+'svelte-meta-tags': patch
+---
+
+fix: `titleTemplate` no longer misinterprets replacement patterns (e.g. `$&`) in `title`, and `fb:app_id` is only rendered when `facebook.appId` is set

--- a/packages/svelte-meta-tags/src/lib/MetaTags.svelte
+++ b/packages/svelte-meta-tags/src/lib/MetaTags.svelte
@@ -18,7 +18,11 @@
     additionalLinkTags = undefined
   }: Partial<MetaTagsProps> = $props();
 
-  let updatedTitle = $derived(title && (titleTemplate?.replace(/%s/g, title) ?? title));
+  let updatedTitle = $derived.by(() => {
+    const t = title;
+    if (!t) return t;
+    return titleTemplate ? titleTemplate.replace(/%s/g, () => t) : t;
+  });
 
   let robotsParams = $derived.by(() => {
     if (!additionalRobotsProps) return '';
@@ -142,7 +146,7 @@
     {/if}
   {/if}
 
-  {#if facebook}
+  {#if facebook?.appId}
     <meta property="fb:app_id" content={facebook.appId} />
   {/if}
 

--- a/tests/svelte-5/src/routes/facebookNoAppId/+page.svelte
+++ b/tests/svelte-5/src/routes/facebookNoAppId/+page.svelte
@@ -1,0 +1,7 @@
+<script>
+  import { MetaTags } from 'svelte-meta-tags';
+</script>
+
+<MetaTags title="Facebook No AppId | Svelte Meta Tags" facebook={{}} />
+
+<h1>Facebook No AppId SEO</h1>

--- a/tests/svelte-5/src/routes/titleTemplateSpecialChars/+page.svelte
+++ b/tests/svelte-5/src/routes/titleTemplateSpecialChars/+page.svelte
@@ -1,0 +1,7 @@
+<script>
+  import { MetaTags } from 'svelte-meta-tags';
+</script>
+
+<MetaTags title="Rock $& Roll" titleTemplate="%s | Svelte Meta Tags" />
+
+<h1>Title Template Special Chars SEO</h1>

--- a/tests/svelte-5/tests/facebookNoAppId.test.ts
+++ b/tests/svelte-5/tests/facebookNoAppId.test.ts
@@ -1,0 +1,7 @@
+import { test, expect } from '@playwright/test';
+
+test('fb:app_id is not rendered when facebook.appId is missing', async ({ page }) => {
+  await page.goto('/facebookNoAppId', { waitUntil: 'domcontentloaded' });
+  await expect(page).toHaveTitle('Facebook No AppId | Svelte Meta Tags');
+  await expect(page.locator('head meta[property="fb:app_id"]')).toHaveCount(0);
+});

--- a/tests/svelte-5/tests/titleTemplateSpecialChars.test.ts
+++ b/tests/svelte-5/tests/titleTemplateSpecialChars.test.ts
@@ -1,0 +1,7 @@
+import { test, expect } from '@playwright/test';
+
+test('titleTemplate inserts titles containing replacement patterns literally', async ({ page }) => {
+  await page.goto('/titleTemplateSpecialChars', { waitUntil: 'domcontentloaded' });
+  await expect(page).toHaveTitle('Rock $& Roll | Svelte Meta Tags');
+  await expect(page.locator('h1')).toContainText('Title Template Special Chars SEO');
+});


### PR DESCRIPTION
## Summary
- `titleTemplate` の `%s` 置換に `String.prototype.replace` の文字列置換を使っていたため、`title` に `$&` 等の置換特殊パターンが含まれると誤展開する問題を修正(関数置換に変更)
- `facebook={{}}` のように `appId` なしで渡された場合に `content` 属性のない無意味な `<meta property="fb:app_id">` が描画される問題を修正

## Test plan
- [x] 新規 e2e 2 件(`titleTemplateSpecialChars`, `facebookNoAppId`)で red→green を確認
- [x] 既存の twitterFallback* 系テスト・normal.test.ts が無変更で pass(優先順位ロジックへの非破壊を確認)
- [x] `pnpm --filter svelte-meta-tags check` exit 0
- [x] `pnpm lint` exit 0
- [x] changeset 追加済み(patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the `/improve` skill (plans/004-metatags-small-fixes.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed title templates so special characters in page titles are preserved correctly.
  * Prevented empty Facebook app IDs from generating an `fb:app_id` meta tag.

* **Tests**
  * Added coverage for special characters in title templates.
  * Added coverage confirming Facebook metadata is omitted when no app ID is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->