### PR TITLE
docs: add install and usage sections to the npm README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,39 @@
 [![MIT](https://img.shields.io/npm/l/svelte-meta-tags)](https://opensource.org/licenses/MIT)
 [![DeepWiki](https://img.shields.io/badge/DeepWiki-oekazuma%2Fsvelte--meta--tags-blue.svg?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACwAAAAyCAYAAAAnWDnqAAAAAXNSR0IArs4c6QAAA05JREFUaEPtmUtyEzEQhtWTQyQLHNak2AB7ZnyXZMEjXMGeK/AIi+QuHrMnbChYY7MIh8g01fJoopFb0uhhEqqcbWTp06/uv1saEDv4O3n3dV60RfP947Mm9/SQc0ICFQgzfc4CYZoTPAswgSJCCUJUnAAoRHOAUOcATwbmVLWdGoH//PB8mnKqScAhsD0kYP3j/Yt5LPQe2KvcXmGvRHcDnpxfL2zOYJ1mFwrryWTz0advv1Ut4CJgf5uhDuDj5eUcAUoahrdY/56ebRWeraTjMt/00Sh3UDtjgHtQNHwcRGOC98BJEAEymycmYcWwOprTgcB6VZ5JK5TAJ+fXGLBm3FDAmn6oPPjR4rKCAoJCal2eAiQp2x0vxTPB3ALO2CRkwmDy5WohzBDwSEFKRwPbknEggCPB/imwrycgxX2NzoMCHhPkDwqYMr9tRcP5qNrMZHkVnOjRMWwLCcr8ohBVb1OMjxLwGCvjTikrsBOiA6fNyCrm8V1rP93iVPpwaE+gO0SsWmPiXB+jikdf6SizrT5qKasx5j8ABbHpFTx+vFXp9EnYQmLx02h1QTTrl6eDqxLnGjporxl3NL3agEvXdT0WmEost648sQOYAeJS9Q7bfUVoMGnjo4AZdUMQku50McDcMWcBPvr0SzbTAFDfvJqwLzgxwATnCgnp4wDl6Aa+Ax283gghmj+vj7feE2KBBRMW3FzOpLOADl0Isb5587h/U4gGvkt5v60Z1VLG8BhYjbzRwyQZemwAd6cCR5/XFWLYZRIMpX39AR0tjaGGiGzLVyhse5C9RKC6ai42ppWPKiBagOvaYk8lO7DajerabOZP46Lby5wKjw1HCRx7p9sVMOWGzb/vA1hwiWc6jm3MvQDTogQkiqIhJV0nBQBTU+3okKCFDy9WwferkHjtxib7t3xIUQtHxnIwtx4mpg26/HfwVNVDb4oI9RHmx5WGelRVlrtiw43zboCLaxv46AZeB3IlTkwouebTr1y2NjSpHz68WNFjHvupy3q8TFn3Hos2IAk4Ju5dCo8B3wP7VPr/FGaKiG+T+v+TQqIrOqMTL1VdWV1DdmcbO8KXBz6esmYWYKPwDL5b5FA1a0hwapHiom0r/cKaoqr+27/XcrS5UwSMbQAAAABJRU5ErkJggg==)](https://deepwiki.com/oekazuma/svelte-meta-tags)
 
+## Install
+
+```sh
+npm install -D svelte-meta-tags
+```
+
+```sh
+pnpm add -D svelte-meta-tags
+```
+
+## Usage
+
+Add `<MetaTags>` to any page or layout:
+
+```svelte
+<script>
+  import { MetaTags } from 'svelte-meta-tags';
+</script>
+
+<MetaTags
+  title="My Page"
+  description="A short description of this page."
+  canonical="https://example.com/my-page"
+  openGraph={{
+    title: 'My Page',
+    description: 'A short description of this page.',
+    images: [{ url: 'https://example.com/og-image.jpg', width: 1200, height: 630, alt: 'My Page' }]
+  }}
+/>
+```
+
+This renders `<title>`, `<meta name="description">`, `<link rel="canonical">`, and the `og:*` tags into `<svelte:head>`. See the [documentation](https://oekazuma.github.io/svelte-meta-tags/) for every property, JSON-LD support, and the layout/page merging pattern.
+
 ## Used by
 
 <a href="https://github.com/oekazuma/svelte-meta-tags/network/dependents">


### PR DESCRIPTION
## Summary
The root `README.md` is copied into the published package on `prepublishOnly` and is what npmjs.com displays for this package. It previously had no install command or usage example — just badges, links, and an affiliate section. This PR adds a minimal Install + Usage section (ported from the docs site's Quickstart) before the existing `## Used by` section. No existing sections were removed or reordered.

## Test plan
- [x] `pnpm lint` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the `/improve` skill (plans/007-npm-readme.md)