### PR TITLE
ci: drop redundant full-workspace build from the test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,11 @@ on:
     paths-ignore:
       - '.changeset/**'
       - '.vscode/**'
-      - '.husky/**'
       - '**/.github/**/*.md'
   pull_request:
     paths-ignore:
       - '.changeset/**'
       - '.vscode/**'
-      - '.husky/**'
       - '**/.github/**/*.md'
 
 concurrency:
@@ -55,8 +53,8 @@ jobs:
         uses: ./.github/workflows/setup-node
       - name: Run svelte-package
         run: pnpm package
-      - name: Run Build
-        run: pnpm build
+      - name: Build example app
+        run: pnpm --filter example build
       - name: Setup Playwright
         uses: ./.github/workflows/setup-playwright
       - name: Run Vitest and Playwright


### PR DESCRIPTION
## Summary
- The `test` job ran `pnpm build` (building docs/example/e2e-app across the whole workspace) even though Playwright's own `webServer` already builds the e2e app itself, and docs is the heaviest workspace in the monorepo. Scoped the test job's build step to `pnpm --filter example build` only, which still exercises example-app buildability without the redundant docs/e2e builds.
- Removed the dead `.husky/**` paths-ignore entries — this repo has no `.husky/` directory.

## Test plan
- [x] `pnpm --filter example build` exit 0 (verifies the new command locally)
- [x] `pnpm lint` exit 0
- [x] CI itself will exercise the new job configuration on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the `/improve` skill (plans/008-ci-streamline.md)