### PR TITLE
ci: run chromium-only on pull requests, full browser matrix on push

### DIFF
--- a/tests/svelte-5/playwright.config.ts
+++ b/tests/svelte-5/playwright.config.ts
@@ -1,36 +1,40 @@
 import { devices, type PlaywrightTestConfig } from '@playwright/test';
 
+// PRs run chromium only for fast feedback; pushes to main (and local runs,
+// where GITHUB_EVENT_NAME is unset) run the full cross-browser matrix.
+const isPullRequest = process.env.GITHUB_EVENT_NAME === 'pull_request';
+
+const allProjects = [
+  {
+    name: 'chromium',
+    use: {
+      ...devices['Desktop Chrome']
+    }
+  },
+  {
+    name: 'firefox',
+    use: {
+      ...devices['Desktop Firefox']
+    }
+  },
+  {
+    name: 'webkit',
+    use: {
+      ...devices['Desktop Safari']
+    }
+  }
+];
+
 const config: PlaywrightTestConfig = {
   timeout: process.env.CI ? 45_000 : 15_000,
-  retries: process.env.CI ? 5 : 0,
+  retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 2 : undefined,
   webServer: {
     command: 'vite build && vite preview --port 4000',
     port: 4000,
     reuseExistingServer: !process.env.CI
   },
-  projects: [
-    {
-      name: 'chromium',
-      use: {
-        ...devices['Desktop Chrome']
-      }
-    },
-
-    {
-      name: 'firefox',
-      use: {
-        ...devices['Desktop Firefox']
-      }
-    },
-
-    {
-      name: 'webkit',
-      use: {
-        ...devices['Desktop Safari']
-      }
-    }
-  ]
+  projects: isPullRequest ? allProjects.filter((p) => p.name === 'chromium') : allProjects
 };
 
 export default config;


### PR DESCRIPTION
## Summary
Every PR ran the full chromium/firefox/webkit matrix with `retries: 5`, which slows PR feedback and lets real flakiness hide behind retries. This PR runs chromium-only on `pull_request` events (fast feedback) and the full 3-browser matrix on `push` (i.e. after merge to main) and local runs, using the `GITHUB_EVENT_NAME` env var GitHub Actions already provides — no `ci.yml` change needed. Also lowers `retries` from 5 to 2 in CI.

**Trade-off (please read before merging):** firefox/webkit-specific regressions will no longer be caught at PR time — only after merging to main. This is an explicit choice to prioritize PR feedback speed; if that trade-off isn't wanted, the one-line `isPullRequest` condition on `projects` can simply be reverted to always use `allProjects`.

## Test plan
- [x] `playwright test --list` confirms chromium-only project selection when `GITHUB_EVENT_NAME=pull_request`, full 3-browser selection on `push` and locally (unset)
- [x] `playwright test --project=chromium` (with `GITHUB_EVENT_NAME=pull_request`) passes
- [x] `pnpm lint` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the `/improve` skill (plans/009-playwright-ci-tuning.md)