### PR TITLE
docs: document CI quality gates in CONTRIBUTING and add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+max_line_length = off

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,17 @@ pnpm install
 2. Make your modifications / additions
 3. Update / Add Documentation
 4. Write / Update Tests. End to end tests are required for all changes and new features.
-5. Open pull request
+5. Run the same checks CI runs before opening a pull request:
+
+```bash
+pnpm lint    # prettier --check . && eslint .
+pnpm check   # svelte-kit sync && svelte-check
+pnpm test    # vitest + Playwright
+```
+
+Run `pnpm format` to auto-fix Prettier issues found by `pnpm lint`.
+
+6. Open pull request
 
 ## Work with Svelte Meta Tags
 


### PR DESCRIPTION
## Summary
- `CONTRIBUTING.md`'s setup steps only mentioned `pnpm test`, not the independent `lint` and `check` CI jobs — a first-time contributor following it verbatim would pass tests locally and still fail CI. Added a step listing `pnpm lint` / `pnpm check` / `pnpm test` before "open pull request".
- Added `.editorconfig` (2-space indent, LF, UTF-8, trim trailing whitespace except in Markdown) matching the repo's existing Prettier config and file conventions, since none existed.

## Test plan
- [x] `pnpm format` produced no unintended diffs after adding `.editorconfig`
- [x] `pnpm lint` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the `/improve` skill (plans/010-contributor-onboarding.md)