### PR TITLE
docs: give the published package its own README instead of copying the repo README

### DIFF
--- a/packages/svelte-meta-tags/README.md
+++ b/packages/svelte-meta-tags/README.md
@@ -1,0 +1,44 @@
+# svelte-meta-tags
+
+Svelte Meta Tags provides components designed to help you manage SEO for Svelte projects.
+
+## Install
+
+```sh
+npm install -D svelte-meta-tags
+```
+
+```sh
+pnpm add -D svelte-meta-tags
+```
+
+## Usage
+
+Add `<MetaTags>` to any page or layout:
+
+```svelte
+<script>
+  import { MetaTags } from 'svelte-meta-tags';
+</script>
+
+<MetaTags
+  title="My Page"
+  description="A short description of this page."
+  canonical="https://example.com/my-page"
+  openGraph={{
+    title: 'My Page',
+    description: 'A short description of this page.',
+    images: [{ url: 'https://example.com/og-image.jpg', width: 1200, height: 630, alt: 'My Page' }]
+  }}
+/>
+```
+
+This renders `<title>`, `<meta name="description">`, `<link rel="canonical">`, and the `og:*` tags into `<svelte:head>`.
+
+## Documentation
+
+Full property reference, JSON-LD support, and the layout/page merging pattern: https://oekazuma.github.io/svelte-meta-tags/
+
+## Repository
+
+https://github.com/oekazuma/svelte-meta-tags

--- a/packages/svelte-meta-tags/package.json
+++ b/packages/svelte-meta-tags/package.json
@@ -31,7 +31,7 @@
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "test": "vitest run",
     "test:bench": "vitest bench",
-    "prepublishOnly": "pnpm package && cp ../../README.md ./"
+    "prepublishOnly": "pnpm package"
   },
   "dependencies": {
     "schema-dts": "^2.0.0"


### PR DESCRIPTION
## Summary
Supersedes #2164 (closed). Instead of maintaining npm-facing content inside the root (GitHub-facing) README via a `prepublishOnly` copy step, `packages/svelte-meta-tags/` now has its own dedicated `README.md` with install instructions, a usage example, and a link to the full docs site. The root `README.md` (badges, "Used by", affiliate section, license) is untouched — it stays purely GitHub-facing.

`prepublishOnly` no longer runs `cp ../../README.md ./`; npm includes `README.md`/`package.json`/`LICENSE*` by default regardless of the `files` field, so the new package-level README is picked up automatically on publish.

## Test plan
- [x] `pnpm --filter svelte-meta-tags package` exit 0, confirmed `README.md` survives the packaging step unchanged (not overwritten by any copy)
- [x] `git diff --stat -- README.md` empty — root README untouched
- [x] `pnpm lint` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the `/improve` skill (plans/011-package-level-readme.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added package documentation covering installation, basic usage, supported SEO properties, rendered metadata, and links to further resources.

* **Chores**
  * Simplified the package publishing process to use the standard packaging command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->