### PR TITLE
docs: prune duplicated meaning from Agent Skills

### DIFF
--- a/skills/svelte-meta-tags-companion/SKILL.md
+++ b/skills/svelte-meta-tags-companion/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: svelte-meta-tags-companion
-description: Use when writing or reviewing code that imports from svelte-meta-tags (MetaTags, JsonLd, deepMerge, defineBaseMetaTags, definePageMetaTags) in an already-set-up project. Catches common mistakes.
+description: Use when writing or reviewing code that imports from svelte-meta-tags (MetaTags, JsonLd, deepMerge, defineBaseMetaTags, definePageMetaTags) in an already-set-up project.
 ---
 
 # svelte-meta-tags: Companion
 
 ## When to use
 
-Use this when writing or reviewing code in this project that imports from `svelte-meta-tags` (`MetaTags`, `JsonLd`, `deepMerge`, `defineBaseMetaTags`, `definePageMetaTags`) in a project that has already set it up. This is a reference for catching common mistakes — not a setup guide (see the `svelte-meta-tags-setup` skill for that).
+This is a reference for catching common mistakes — not a setup guide (see the `svelte-meta-tags-setup` skill for that).
 
 ## Common mistakes
 

--- a/skills/svelte-meta-tags-setup/SKILL.md
+++ b/skills/svelte-meta-tags-setup/SKILL.md
@@ -1,13 +1,9 @@
 ---
 name: svelte-meta-tags-setup
-description: Use when adding svelte-meta-tags to a Svelte/SvelteKit project for the first time, or when asked to add SEO/meta tag support. Detects project structure and wires up the correct base+page merge pattern.
+description: Use when adding svelte-meta-tags or SEO/meta tag support to a Svelte/SvelteKit project for the first time.
 ---
 
 # svelte-meta-tags: Setup
-
-## When to use
-
-Use this when adding `svelte-meta-tags` to a Svelte or SvelteKit project for the first time, or when asked to add SEO/meta tag support to a project that doesn't have it wired up yet.
 
 ## Step 1: Detect whether this is a SvelteKit project
 
@@ -50,8 +46,6 @@ export const load = () => {
   };
 };
 ```
-
-If the file already has a `load` function returning other data, add the spread into the existing return object instead of replacing the function.
 
 ## Step 3: Check for nested layouts
 
@@ -115,7 +109,7 @@ Not every route needs its own `+page.ts` — only add one where the page needs t
 {@render children()}
 ```
 
-Import `page` from **`$app/state`**, not `$app/stores` — `$app/stores` is the pre-Svelte-5 API and requires extra work (a `{#key}` block) to stay reactive across navigation. `$app/state` with `$derived` handles this correctly with no extra wrapping needed.
+Import `page` from **`$app/state`**, not `$app/stores` — the pre-Svelte-5 API that needs extra reactivity workarounds this pattern doesn't require.
 
 If Step 3 added nested-layout overrides, read the base tags from `page.data` instead, so section-level overrides actually reach this component:
 


### PR DESCRIPTION
## Summary

Applies the `writing-great-skills` rubric (duplication / no-op pruning) to the two Agent Skills added in #2171:

- **description ↔ body duplication**: both `SKILL.md` files had a body `## When to use` section restating the frontmatter `description` almost verbatim. The description already carries this triggering information — the body doesn't need to re-justify why it's being read. Removed from `setup` entirely; trimmed in `companion` to keep only the cross-reference clause not present in the description.
- **description trigger duplication**: `setup`'s description stated the same trigger via two synonymous phrasings ("adding for the first time" / "asked to add SEO/meta tag support"); collapsed into one. Both descriptions also had a trailing sentence restating body content without adding new trigger information — trimmed.
- **in-step duplication**: `setup` Step 2 stated the same "merge into existing return, don't overwrite" instruction twice back-to-back (once in a bullet, once again right after the code sample). Removed the second instance.
- **cross-skill duplication**: the `$app/stores` vs `$app/state` rationale was explained in both `setup` and `companion`, with drifted wording ("a `{#key}` block" vs "a `{#key $page}` wrapper" — a Minor finding from #2171's final review that was deferred, not fixed). `companion`'s mistake catalog is the natural home for the full explanation; `setup`'s version is now a short, **self-contained** rule (no dependency on `companion` being installed, since the two skills are documented as independently installable).

No content/behavior changes — pure documentation pruning of the two `SKILL.md` files.

## Test plan
- [x] `node scripts/validate-skills.mjs` exit 0
- [x] `pnpm lint` exit 0
- [x] Diff reviewed: touches only the two `SKILL.md` files, no unrelated changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified when to use the Svelte meta tags review and setup guidance.
  * Distinguished review guidance from initial setup instructions.
  * Simplified instructions for integrating metadata with existing page data.
  * Updated reactivity guidance for importing page data in layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->