### PR TITLE
docs: mention @sv-addon/svelte-meta-tags community add-on in quickstart

### DIFF
--- a/docs/content/ja/quickstart.mdx
+++ b/docs/content/ja/quickstart.mdx
@@ -45,7 +45,7 @@ yarn add -D svelte-meta-tags
 
 ## 別の方法: Svelte CLIでセットアップ
 
-CLIでのセットアップを好む場合は、コミュニティメンテナンスの[`@sv-addon/svelte-meta-tags`](https://www.npmjs.com/package/@sv-addon/svelte-meta-tags)アドオンを使うと、`<MetaTags>`のセットアップを自動化できます:
+既存のプロジェクトでCLIでのセットアップを好む場合は、コミュニティメンテナンスの[`@sv-addon/svelte-meta-tags`](https://www.npmjs.com/package/@sv-addon/svelte-meta-tags)アドオンを使うと、`<MetaTags>`のセットアップを自動化できます。コミュニティアドオンはSvelteメンテナーによるレビューを受けていないため、利用は自己判断でお願いします:
 
 ```sh
 npx sv add @sv-addon/svelte-meta-tags

--- a/docs/content/ja/quickstart.mdx
+++ b/docs/content/ja/quickstart.mdx
@@ -43,6 +43,16 @@ yarn add -D svelte-meta-tags
 
 これだけで、`<title>`、`<meta name="description">`、`<link rel="canonical">`、そして`og:*`タグが`<svelte:head>`にレンダリングされます。
 
+## 別の方法: Svelte CLIでセットアップ
+
+CLIでのセットアップを好む場合は、コミュニティメンテナンスの[`@sv-addon/svelte-meta-tags`](https://www.npmjs.com/package/@sv-addon/svelte-meta-tags)アドオンを使うと、`<MetaTags>`のセットアップを自動化できます:
+
+```sh
+npx sv add @sv-addon/svelte-meta-tags
+```
+
+コミュニティアドオンについての詳細は[`sv add`のドキュメント](https://svelte.dev/docs/cli/sv-add#Community-add-ons)を参照してください。
+
 ## 次のステップ
 
 <CardGroup cols={2}>

--- a/docs/content/quickstart.mdx
+++ b/docs/content/quickstart.mdx
@@ -43,9 +43,9 @@ Add `<MetaTags>` to any page or layout:
 
 That's it — this renders `<title>`, `<meta name="description">`, `<link rel="canonical">`, and the `og:*` tags into `<svelte:head>`.
 
-## Alternative: scaffold with the Svelte CLI
+## Alternative: set up with the Svelte CLI
 
-Prefer a CLI-driven setup? The community-maintained [`@sv-addon/svelte-meta-tags`](https://www.npmjs.com/package/@sv-addon/svelte-meta-tags) add-on wires up `<MetaTags>` for you:
+Prefer a CLI-driven setup for an existing project? The community-maintained [`@sv-addon/svelte-meta-tags`](https://www.npmjs.com/package/@sv-addon/svelte-meta-tags) add-on wires up `<MetaTags>` for you. Community add-ons aren't reviewed by the Svelte maintainers, so use them at your discretion:
 
 ```sh
 npx sv add @sv-addon/svelte-meta-tags

--- a/docs/content/quickstart.mdx
+++ b/docs/content/quickstart.mdx
@@ -43,6 +43,16 @@ Add `<MetaTags>` to any page or layout:
 
 That's it — this renders `<title>`, `<meta name="description">`, `<link rel="canonical">`, and the `og:*` tags into `<svelte:head>`.
 
+## Alternative: scaffold with the Svelte CLI
+
+Prefer a CLI-driven setup? The community-maintained [`@sv-addon/svelte-meta-tags`](https://www.npmjs.com/package/@sv-addon/svelte-meta-tags) add-on wires up `<MetaTags>` for you:
+
+```sh
+npx sv add @sv-addon/svelte-meta-tags
+```
+
+See the [`sv add` docs](https://svelte.dev/docs/cli/sv-add#Community-add-ons) for more on community add-ons.
+
 ## Next steps
 
 <CardGroup cols={2}>


### PR DESCRIPTION
## Summary
- Adds a short "Alternative: scaffold with the Svelte CLI" section to the Quickstart page (en + ja) pointing to the community-maintained `@sv-addon/svelte-meta-tags` `sv add` add-on, for users who prefer a CLI-driven setup over the manual steps.
- No changeset needed — docs-only change per `AGENTS.md`.

Related to #2181.

## Test plan
- [x] Verified `npx sv add @sv-addon/svelte-meta-tags` scaffolds the canonical `defineBaseMetaTags`/`definePageMetaTags` + `deepMerge` + `<MetaTags>` pattern against `svelte-meta-tags@5.0.2`, and the generated project builds cleanly.
- [x] `pnpm exec prettier --check docs/content/quickstart.mdx docs/content/ja/quickstart.mdx` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an alternative quickstart using the Svelte CLI.
  * Documented automatic `<MetaTags>` setup using the community add-on via the `npx sv add `@sv-addon/svelte-meta-tags`` command.
  * Added a link to the Svelte CLI community add-ons documentation.
  * Updated both English and Japanese quickstart guides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->