### PR TITLE
chore: auto-merge non-major renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,13 @@
     "enabled": true
   },
   "rangeStrategy": "bump",
+  "platformAutomerge": true,
   "packageRules": [
+    {
+      "description": "Auto-merge everything except major updates (those need review) — CI still has to pass first.",
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
+    },
     {
       "groupName": "dependencies",
       "matchDepTypes": ["dependencies"]


### PR DESCRIPTION
## Summary
- Enables `platformAutomerge` and adds a packageRule so minor/patch/pin/digest Renovate PRs merge automatically once CI passes; major updates still require manual review.
- Mirrors the automerge policy already used on [svelte-vitals](https://github.com/oekazuma/svelte-vitals/blob/main/renovate.json).
- `main` has no required PR reviews or rulesets configured, so no bypass-list setup is needed for this to take effect (unlike svelte-vitals).

## Test plan
- [x] Validated `renovate.json` is well-formed JSON.
- N/A for functional tests — config-only change, no changeset needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automatic merging for eligible minor, patch, pin, and digest dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->