### PR TITLE
chore: exclude schema-dts from renovate automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -41,8 +41,10 @@
       "matchPackageNames": ["@sveltejs/{/,}**", "svelte{/,}**"]
     },
     {
+      "description": "schema-dts ships as a runtime dependency of the published package, so its updates reach every consumer — keep them manually reviewed.",
       "groupName": "schema-dts",
-      "matchPackageNames": ["schema-dts"]
+      "matchPackageNames": ["schema-dts"],
+      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Follow-up to #2185. Adds `automerge: false` to the `schema-dts` packageRule so its updates require manual review, since it's a runtime dependency of the published `svelte-meta-tags` package (used by `JsonLd`'s types) and ships directly to every consumer — unlike the rest of the auto-merged non-major updates.

## Test plan
- [x] Validated `renovate.json` is well-formed JSON.
- N/A for functional tests — config-only change, no changeset needed.