### PR TITLE
ci: run svelte-kit sync before playwright test

### DIFF
--- a/tests/svelte-5/package.json
+++ b/tests/svelte-5/package.json
@@ -7,7 +7,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-    "test": "playwright test"
+    "test": "svelte-kit sync && playwright test"
   },
   "devDependencies": {
     "@playwright/test": "catalog:",


### PR DESCRIPTION
## 背景

`main` の CI (`test` ジョブ) が失敗していました。
https://github.com/oekazuma/svelte-meta-tags/actions/runs/30320810301/job/90254150080

```
Error: Failed to load tsconfig file at tests/svelte-5/tsconfig.json:
Failed to resolve "extends" path "./.svelte-kit/tsconfig.json"
```

## 原因

`@playwright/test` 1.62.0 (#2188) から、Playwright が設定ファイルを読み込む際に同ディレクトリの `tsconfig.json` を厳密に解決するようになりました。

`tests/svelte-5/tsconfig.json` は `"extends": "./.svelte-kit/tsconfig.json"` を持ちますが、この生成物は `svelte-kit sync` でしか作られません。CI の `test` ジョブは `pnpm package` → `pnpm --filter example build` → `pnpm test` の順で、`tests/svelte-5` 側の `svelte-kit sync` / `vite build` が一度も走らないため、`.svelte-kit/tsconfig.json` が存在せず設定読み込みの時点で失敗していました。`playwright.config.ts` の `webServer` で `vite build` は走りますが、それは設定読み込み後なので間に合いません。

## 変更内容

`tests/svelte-5` の `test` スクリプトに `svelte-kit sync` を前置しました。既存の `check` スクリプトと同じパターンです。

ワークフローにステップを追加するのではなくスクリプト側で解決しているため、`pnpm --filter svelte-5 test` をクリーンなチェックアウトから単独実行しても動作します。

## 検証

- `.svelte-kit` を削除したクリーン状態で同一エラーを再現
- 修正後、`.svelte-kit` 削除状態から `pnpm run test --project=chromium` で 29 passed
- `pnpm lint` 通過

テスト基盤のみの変更のため changeset は不要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the test workflow to synchronize the SvelteKit project before running Playwright tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->