### PR TITLE
test: assert head output in-process, extract robots serialization, layer the test strategy

### DIFF
--- a/.changeset/lucky-donkeys-shave.md
+++ b/.changeset/lucky-donkeys-shave.md
@@ -1,0 +1,7 @@
+---
+'svelte-meta-tags': patch
+---
+
+refactor: move the `<meta name="robots">` content builder out of `MetaTags.svelte` into an internal `robots` module.
+
+The rendered output is unchanged. The published package gains `dist/robots.js` and `dist/robots.d.ts`, which `dist/MetaTags.svelte` imports at runtime. The module is not listed in `exports`, so it stays internal and there is no new public API.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ pnpm test                  # runs every workspace's `test` (vitest in lib, playw
 Per-workspace commands (use these to scope work):
 
 ```bash
-# Vitest: helper units (deepMerge / define) + in-process rendering of
+# Vitest: helper units (deepMerge / define / robots) + in-process rendering of
 # MetaTags and JsonLd. No build, no browser — this is the fast feedback loop.
 pnpm --filter svelte-meta-tags test
 pnpm --filter svelte-meta-tags test:bench
@@ -80,7 +80,7 @@ The public surface is intentionally small (`packages/svelte-meta-tags/src/lib/in
 - **Twitter fallback chain**: `twitter.title || openGraph.title || updatedTitle` (and the same shape for `description`). The `twitterFallback*` test routes lock this in — preserve the precedence when touching `MetaTags.svelte`.
 - **OpenGraph fallbacks**: `og:title` falls back to the (templated) `title`, `og:description` to `description`, and `og:url` to `canonical`. These only render when the `openGraph` prop is present at all.
 - **`titleTemplate`**: `%s` placeholder is substituted with `title`; if `title` is missing, the template is **not** applied alone — no `<title>` is rendered.
-- **`robots` default**: `'index,follow'` — a `<meta name="robots">` tag is rendered even when the consumer passes nothing.
+- **`robots` default**: `'index,follow'` — a `<meta name="robots">` tag is rendered even when the consumer passes nothing. `serializeRobots` in `robots.ts` (internal, not exported from `index.ts`) owns the content string and returns `null` when no tag should render. The directive order in its `DIRECTIVES` table is asserted by tests — append, don't insert. Falsy values are dropped, so `maxSnippet: 0` emits nothing.
 - **`og:type`-conditional blocks**: `article`, `book`, `profile`, and `video.movie | video.episode | video.tv_show | video.other` each render a distinct sub-block. Adding a new structured type means matching it in the `og:type.toLowerCase()` chain _and_ adding fields to `OpenGraph` in `types.d.ts`.
 - **`additionalMetaTags`**: when an entry has `httpEquiv`, it is emitted as `http-equiv` (HTML attribute name). Don't normalize this away.
 - **`openGraph.image` vs `openGraph.images`**: `image` (singular) is an alias prepended to `images`; both render as `og:image`. See `openGraphImage.test.ts`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ This is a **pnpm workspace monorepo**. The pnpm version is pinned via `packageMa
 Workspace members:
 
 - `packages/svelte-meta-tags/` — the published library (the only public package). Source is in `src/lib/`. The package consumes itself via the SvelteKit dev app under `src/routes/` for local iteration.
-- `tests/svelte-5/` — a SvelteKit app dedicated to **Playwright e2e tests**. Each route under `src/routes/<feature>/` corresponds to a `tests/<feature>.test.ts` that asserts the rendered `<head>` markup. This is where new feature behavior must be verified (per `CONTRIBUTING.md`).
+- `tests/svelte-5/` — a SvelteKit app dedicated to **Playwright e2e tests**. Each route under `src/routes/<feature>/` corresponds to a `tests/<feature>.test.ts` that asserts the rendered `<head>` markup. This layer proves the tags reach a real browser; the tag-by-tag assertions belong in the in-process tests described below.
 - `example/` — a runnable SvelteKit demo of the library; not part of the test pipeline.
 - `docs/` — Blume (a markdown-first docs framework on Astro) documentation site (deployed to GitHub Pages by `.github/workflows/deploy-docs.yml` only when `docs/**` changes). It is **bilingual**: English pages live in `docs/content/`, Japanese translations in `docs/content/ja/` (mirrored paths). Site config (i18n, redirects, deployment base) lives in `docs/blume.config.ts`; section ordering comes from `meta.$.ts` files in the English content directories plus each page's `sidebar.order` frontmatter. When documenting a feature, update **both** locales.
 
@@ -33,7 +33,8 @@ pnpm test                  # runs every workspace's `test` (vitest in lib, playw
 Per-workspace commands (use these to scope work):
 
 ```bash
-# Unit tests + benchmarks for deepMerge / define helpers
+# Vitest: helper units (deepMerge / define) + in-process rendering of
+# MetaTags and JsonLd. No build, no browser — this is the fast feedback loop.
 pnpm --filter svelte-meta-tags test
 pnpm --filter svelte-meta-tags test:bench
 pnpm --filter svelte-meta-tags exec vitest run tests/deepMerge/deepMerge.test.ts   # single file
@@ -46,11 +47,17 @@ pnpm --filter svelte-5 exec playwright test --project=chromium                  
 
 **`tests/svelte-5` imports `svelte-meta-tags` as `workspace:*` and resolves it from `dist/`.** Run `pnpm package` (or `pnpm --filter svelte-meta-tags package`) first whenever you change library source — CI does this before `pnpm build` and `pnpm test`. Without it, e2e tests will run against stale published artifacts.
 
+### In-process rendering tests
+
+`packages/svelte-meta-tags/tests/helpers/head.ts` renders a component with `render()` from `svelte/server` and parses what it emitted, so `<head>` output can be asserted without a build or a browser. `renderHead(MetaTags, props)` / `renderBody(JsonLd, props)` return `{ title, tags, jsonLd, html }`; `metaContent`, `metaContents`, `metaTags` and `links` read tags back out.
+
+**Assert new tag behavior here first** (`tests/metaTags/`, `tests/jsonLd/`) — it needs no fixture route and runs in milliseconds. Add an e2e route under `tests/svelte-5/` only when the behavior genuinely depends on the browser. Two things the in-process layer cannot see: `$effect` does not run during SSR (the `additionalRobotsProps` warning is covered by `robotsAnother.test.ts`), and client-side navigation.
+
 ## Library architecture
 
 The public surface is intentionally small (`packages/svelte-meta-tags/src/lib/index.ts`):
 
-- **`<MetaTags>`** — single Svelte 5 component (`MetaTags.svelte`) that renders **all** SEO/meta/link/Twitter/OpenGraph/Facebook tags into `<svelte:head>`. It uses runes (`$props`, `$derived`, `$effect`) and accepts `Partial<MetaTagsProps>`. Adding a new meta surface means: extend `types.d.ts`, render the conditional block in `MetaTags.svelte`, add a route under `tests/svelte-5/src/routes/<feature>/` and a corresponding `tests/<feature>.test.ts`, document it under `docs/content/` (en + ja), and add a changeset (see Releases).
+- **`<MetaTags>`** — single Svelte 5 component (`MetaTags.svelte`) that renders **all** SEO/meta/link/Twitter/OpenGraph/Facebook tags into `<svelte:head>`. It uses runes (`$props`, `$derived`, `$effect`) and accepts `Partial<MetaTagsProps>`. Adding a new meta surface means: extend `types.d.ts`, render the conditional block in `MetaTags.svelte`, assert it in `packages/svelte-meta-tags/tests/metaTags/`, document it under `docs/content/` (en + ja), and add a changeset (see Releases).
 - **Agent Skills** (`skills/svelte-meta-tags-setup/`, `skills/svelte-meta-tags-companion/`) — distributed via `npx skills add` (see `docs/content/guides/agent-skills.md`). If the canonical `deepMerge` + `define*` + `<MetaTags>` wiring pattern changes, or a new common usage mistake is identified, update the relevant `SKILL.md` alongside the docs change.
 - **`<JsonLd>`** — renders `application/ld+json` either in `<svelte:head>` (`output="head"`, default) or inline (`output="body"`). The `schema` prop accepts `schema-dts` types, plain objects, arrays (multiple JSON-LD blocks), or a `{ '@graph': [...] }` wrapper. `@context: https://schema.org` is auto-injected. The literal `<script>` string is split (`'<scri' + 'pt'`) on purpose to bypass HTML parser confusion — preserve this when editing.
 - **`deepMerge(target, source)`** — recursive merge utility used by consumers to combine `baseMetaTags` (layout) with `pageMetaTags` (page). Arrays are **replaced**, not concatenated. `Date` and functions are never merged into — and when the **target** value is a `Date`/function it wins over the source value (the reverse of the usual source-wins rule). A source value of `undefined` keeps the target value.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ pnpm install
 
 2. Make your modifications / additions
 3. Update / Add Documentation
-4. Write / Update Tests. End to end tests are required for all changes and new features.
+4. Write / Update Tests. See [Testing](#testing) for which layer a test belongs in.
 5. Run the same checks CI runs before opening a pull request:
 
 ```bash
@@ -38,7 +38,42 @@ All the code for the library is located in the `packages/svelte-meta-tags/src/li
 
 The `tests/svelte-5/src/routes` directory contains a fully working SvelteKit app. This will be used for end-to-end testing. You can run `pnpm dev` to run this app. You can also run it in a production build by running `pnpm build` and `pnpm preview`.
 
-To run Playwright, you can run `pnpm test`.
+## Testing
+
+Tests live in two layers. Put a test in the lowest layer that can actually observe the behavior.
+
+### Vitest — the default
+
+`packages/svelte-meta-tags/tests/` runs against the source with no build and no browser, so the whole suite finishes in well under a second.
+
+```bash
+pnpm --filter svelte-meta-tags test
+pnpm --filter svelte-meta-tags exec vitest run tests/metaTags/twitter.test.ts   # single file
+```
+
+This is where **most tests belong**, including tests for the components:
+
+- `.ts` modules (`deepMerge`, `define`, `robots`) are called directly.
+- `<MetaTags>` and `<JsonLd>` are rendered in process with `render()` from `svelte/server`, and the markup they produced is parsed and asserted. `tests/helpers/head.ts` provides `renderHead` / `renderBody`, plus `metaContent`, `metaContents`, `metaTags` and `links` to read tags back out.
+
+Adding a meta tag, changing a fallback chain or fixing an escaping bug needs a test here — and usually nothing else.
+
+### Playwright — only when the browser matters
+
+`tests/svelte-5/` builds the library, builds a SvelteKit app against `dist/`, serves it and drives real browsers. That is slow, so keep it for things Vitest genuinely cannot see:
+
+```bash
+pnpm --filter svelte-5 test                                   # chromium + firefox + webkit
+pnpm --filter svelte-5 exec playwright test --project=chromium
+```
+
+- `$effect` does not run during server rendering, so effect-driven behavior (such as the `additionalRobotsProps` warning) is only observable here.
+- Client-side navigation, hydration and anything that depends on a real DOM.
+- A smoke check that tags actually reach `<head>` in a real browser.
+
+**`tests/svelte-5` resolves `svelte-meta-tags` from `dist/`**, so run `pnpm package` after changing library source or you will be testing stale output.
+
+Run the same checks CI runs before opening a pull request — see step 5 above.
 
 ## Releases
 

--- a/packages/svelte-meta-tags/src/lib/MetaTags.svelte
+++ b/packages/svelte-meta-tags/src/lib/MetaTags.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { MetaTagsProps } from './types';
+  import { ROBOTS_CONFLICT_WARNING, serializeRobots } from './robots';
 
   let {
     title = undefined,
@@ -24,29 +25,11 @@
     return titleTemplate ? titleTemplate.replace(/%s/g, () => t) : t;
   });
 
-  let robotsParams = $derived.by(() => {
-    if (!additionalRobotsProps) return '';
-    const {
-      nosnippet,
-      maxSnippet,
-      maxImagePreview,
-      maxVideoPreview,
-      noarchive,
-      noimageindex,
-      notranslate,
-      unavailableAfter
-    } = additionalRobotsProps;
-
-    return `${nosnippet ? ',nosnippet' : ''}${maxSnippet ? `,max-snippet:${maxSnippet}` : ''}${
-      maxImagePreview ? `,max-image-preview:${maxImagePreview}` : ''
-    }${noarchive ? ',noarchive' : ''}${unavailableAfter ? `,unavailable_after:${unavailableAfter}` : ''}${
-      noimageindex ? ',noimageindex' : ''
-    }${maxVideoPreview ? `,max-video-preview:${maxVideoPreview}` : ''}${notranslate ? ',notranslate' : ''}`;
-  });
+  let robotsContent = $derived(serializeRobots(robots, additionalRobotsProps));
 
   $effect(() => {
     if (!robots && additionalRobotsProps) {
-      console.warn('additionalRobotsProps cannot be used when robots is set to false');
+      console.warn(ROBOTS_CONFLICT_WARNING);
     }
   });
 </script>
@@ -56,8 +39,8 @@
     <title>{updatedTitle}</title>
   {/if}
 
-  {#if robots !== false}
-    <meta name="robots" content="{robots}{robotsParams}" />
+  {#if robotsContent !== null}
+    <meta name="robots" content={robotsContent} />
   {/if}
 
   {#if description}

--- a/packages/svelte-meta-tags/src/lib/robots.ts
+++ b/packages/svelte-meta-tags/src/lib/robots.ts
@@ -1,0 +1,41 @@
+import type { AdditionalRobotsProps, MetaTagsProps } from './types';
+
+export const ROBOTS_CONFLICT_WARNING = 'additionalRobotsProps cannot be used when robots is set to false';
+
+type Directive = readonly [key: keyof AdditionalRobotsProps, format: (value: string | number | boolean) => string];
+
+/**
+ * Order is significant: it is the order the directives are emitted in and is
+ * covered by tests. Append new directives at the end rather than inserting.
+ */
+const DIRECTIVES: readonly Directive[] = [
+  ['nosnippet', () => 'nosnippet'],
+  ['maxSnippet', (value) => `max-snippet:${value}`],
+  ['maxImagePreview', (value) => `max-image-preview:${value}`],
+  ['noarchive', () => 'noarchive'],
+  ['unavailableAfter', (value) => `unavailable_after:${value}`],
+  ['noimageindex', () => 'noimageindex'],
+  ['maxVideoPreview', (value) => `max-video-preview:${value}`],
+  ['notranslate', () => 'notranslate']
+];
+
+/**
+ * Build the `content` value for `<meta name="robots">`.
+ *
+ * Falsy directive values are dropped, so `maxSnippet: 0` emits nothing.
+ *
+ * @returns the content string, or `null` when no tag should be rendered at all
+ */
+export const serializeRobots = (
+  robots: MetaTagsProps['robots'],
+  additionalRobotsProps: AdditionalRobotsProps | undefined
+): string | null => {
+  if (robots === false) return null;
+  if (!additionalRobotsProps) return `${robots}`;
+
+  const params = DIRECTIVES.filter(([key]) => additionalRobotsProps[key]).map(
+    ([key, format]) => `,${format(additionalRobotsProps[key] as string | number | boolean)}`
+  );
+
+  return `${robots}${params.join('')}`;
+};

--- a/packages/svelte-meta-tags/src/lib/robots.ts
+++ b/packages/svelte-meta-tags/src/lib/robots.ts
@@ -33,9 +33,16 @@ export const serializeRobots = (
   if (robots === false) return null;
   if (!additionalRobotsProps) return `${robots}`;
 
-  const params = DIRECTIVES.filter(([key]) => additionalRobotsProps[key]).map(
-    ([key, format]) => `,${format(additionalRobotsProps[key] as string | number | boolean)}`
-  );
+  // Plain loop rather than filter/map/join. The intermediate arrays are ~6x
+  // slower in isolation; inside a full component render the difference is lost
+  // in the noise, so this is a cheap default rather than a hot-path fix.
+  let content = `${robots}`;
 
-  return `${robots}${params.join('')}`;
+  for (const [key, format] of DIRECTIVES) {
+    const value = additionalRobotsProps[key];
+
+    if (value) content += `,${format(value)}`;
+  }
+
+  return content;
 };

--- a/packages/svelte-meta-tags/tests/helpers/head.ts
+++ b/packages/svelte-meta-tags/tests/helpers/head.ts
@@ -1,0 +1,89 @@
+import { render } from 'svelte/server';
+import type { Component } from 'svelte';
+
+export interface RenderedTag {
+  tag: string;
+  attrs: Record<string, string>;
+}
+
+export interface Rendered {
+  title: string | undefined;
+  tags: RenderedTag[];
+  jsonLd: string[];
+  html: string;
+}
+
+const ENTITIES: Record<string, string> = {
+  '&amp;': '&',
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&#39;': "'"
+};
+
+const unescape = (value: string) => value.replace(/&(?:amp|lt|gt|quot|#39);/g, (entity) => ENTITIES[entity]);
+
+/**
+ * Svelte's SSR output interleaves hydration markers with the real markup.
+ * They carry no meaning for a `<head>` assertion, so drop them before parsing.
+ */
+const stripMarkers = (html: string) => html.replace(/<!--[\s\S]*?-->/g, '');
+
+const parseAttrs = (raw: string) => {
+  const attrs: Record<string, string> = {};
+
+  for (const [, name, value] of raw.matchAll(/([a-zA-Z_:][-a-zA-Z0-9_:.]*)(?:="([^"]*)")?/g)) {
+    attrs[name] = value === undefined ? '' : unescape(value);
+  }
+
+  return attrs;
+};
+
+/**
+ * Svelte escapes `&`, `"` and `<` inside attribute values but leaves `>` raw,
+ * so the attribute region has to be scanned quote-aware rather than up to the
+ * first `>`.
+ */
+const TAG = /<(meta|link)\b((?:[^>"]|"[^"]*")*?)\/?>/g;
+
+const parse = (raw: string): Rendered => {
+  const jsonLd = [...raw.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)].map(
+    ([, json]) => json
+  );
+  const html = stripMarkers(raw.replace(/<script type="application\/ld\+json">[\s\S]*?<\/script>/g, ''));
+  const title = html.match(/<title>([\s\S]*?)<\/title>/)?.[1];
+
+  const tags = [...html.matchAll(TAG)].map(([, tag, attrs]) => ({ tag, attrs: parseAttrs(attrs) }));
+
+  return { title: title === undefined ? undefined : unescape(title), tags, jsonLd, html };
+};
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const renderParts = (component: Component<any>, props: Record<string, unknown>) =>
+  render(component, { props } as any) as { head: string; body: string };
+
+/** Render a component and parse everything it put into `<svelte:head>`. */
+export const renderHead = (component: Component<any>, props: Record<string, unknown> = {}): Rendered =>
+  parse(renderParts(component, props).head);
+
+/** Render a component and parse its inline (non-head) output. */
+export const renderBody = (component: Component<any>, props: Record<string, unknown> = {}): Rendered =>
+  parse(renderParts(component, props).body);
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+const keyOf = (tag: RenderedTag) => tag.attrs.name ?? tag.attrs.property;
+
+/** All `content` values emitted for a meta `name`/`property`, in document order. */
+export const metaContents = (rendered: Rendered, key: string): string[] =>
+  rendered.tags.filter((tag) => tag.tag === 'meta' && keyOf(tag) === key).map((tag) => tag.attrs.content);
+
+/** The single `content` value for a meta `name`/`property`, or `undefined` when the tag is absent. */
+export const metaContent = (rendered: Rendered, key: string): string | undefined => metaContents(rendered, key)[0];
+
+/** Every meta tag carrying a `name`/`property`, so a test can assert which attribute was used. */
+export const metaTags = (rendered: Rendered, key: string): RenderedTag[] =>
+  rendered.tags.filter((tag) => tag.tag === 'meta' && keyOf(tag) === key);
+
+/** All `<link>` tags with the given `rel`. */
+export const links = (rendered: Rendered, rel: string): RenderedTag[] =>
+  rendered.tags.filter((tag) => tag.tag === 'link' && tag.attrs.rel === rel);

--- a/packages/svelte-meta-tags/tests/index/index.test.ts
+++ b/packages/svelte-meta-tags/tests/index/index.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'vitest';
+import * as publicApi from '$lib/index';
+
+/**
+ * The published entry point is the library's interface. Anything added here is
+ * a public API change and needs a changeset; anything removed is a breaking one.
+ */
+describe('public exports', () => {
+  test('exports exactly the documented runtime surface', () => {
+    expect(Object.keys(publicApi).sort()).toEqual([
+      'JsonLd',
+      'MetaTags',
+      'deepMerge',
+      'defineBaseMetaTags',
+      'definePageMetaTags'
+    ]);
+  });
+
+  test('components are exported as components', () => {
+    expect(typeof publicApi.MetaTags).toBe('function');
+    expect(typeof publicApi.JsonLd).toBe('function');
+  });
+
+  test('helpers are exported as functions', () => {
+    expect(typeof publicApi.deepMerge).toBe('function');
+    expect(typeof publicApi.defineBaseMetaTags).toBe('function');
+    expect(typeof publicApi.definePageMetaTags).toBe('function');
+  });
+
+  test('internal modules stay internal', () => {
+    expect(publicApi).not.toHaveProperty('serializeRobots');
+    expect(publicApi).not.toHaveProperty('ROBOTS_CONFLICT_WARNING');
+  });
+});

--- a/packages/svelte-meta-tags/tests/jsonLd/jsonLd.test.ts
+++ b/packages/svelte-meta-tags/tests/jsonLd/jsonLd.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from 'vitest';
+import JsonLd from '$lib/JsonLd.svelte';
+import { renderBody, renderHead } from '../helpers/head';
+
+const article = { '@type': 'Article', headline: 'Headline' };
+
+describe('output target', () => {
+  test('renders into the head by default', () => {
+    expect(renderHead(JsonLd, { schema: article }).jsonLd).toHaveLength(1);
+    expect(renderBody(JsonLd, { schema: article }).jsonLd).toHaveLength(0);
+  });
+
+  test('renders into the head for output="head"', () => {
+    expect(renderHead(JsonLd, { schema: article, output: 'head' }).jsonLd).toHaveLength(1);
+  });
+
+  test('renders inline for output="body"', () => {
+    expect(renderBody(JsonLd, { schema: article, output: 'body' }).jsonLd).toHaveLength(1);
+    expect(renderHead(JsonLd, { schema: article, output: 'body' }).jsonLd).toHaveLength(0);
+  });
+
+  test('renders nothing when schema is omitted', () => {
+    expect(renderHead(JsonLd, {}).jsonLd).toHaveLength(0);
+    expect(renderBody(JsonLd, {}).jsonLd).toHaveLength(0);
+  });
+
+  test('renders nothing for a non-object schema', () => {
+    expect(renderHead(JsonLd, { schema: 'not an object' }).jsonLd).toHaveLength(0);
+  });
+});
+
+describe('@context injection', () => {
+  test('injects the schema.org context', () => {
+    const [json] = renderHead(JsonLd, { schema: article }).jsonLd;
+
+    expect(JSON.parse(json)).toEqual({ '@context': 'https://schema.org', '@type': 'Article', headline: 'Headline' });
+  });
+
+  test('injects the context into every entry of an array', () => {
+    const [json] = renderHead(JsonLd, { schema: [article, { '@type': 'Person', name: 'Jane' }] }).jsonLd;
+    const parsed = JSON.parse(json);
+
+    expect(parsed).toHaveLength(2);
+    expect(parsed[0]['@context']).toBe('https://schema.org');
+    expect(parsed[1]).toEqual({ '@context': 'https://schema.org', '@type': 'Person', name: 'Jane' });
+  });
+
+  test('wraps a @graph without touching its members', () => {
+    const graph = { '@graph': [article, { '@type': 'Person', name: 'Jane' }] };
+    const [json] = renderHead(JsonLd, { schema: graph }).jsonLd;
+    const parsed = JSON.parse(json);
+
+    expect(parsed['@context']).toBe('https://schema.org');
+    expect(parsed['@graph']).toEqual(graph['@graph']);
+  });
+
+  test('a caller-supplied @context wins', () => {
+    const [json] = renderHead(JsonLd, { schema: { '@context': 'https://example.test', ...article } }).jsonLd;
+
+    expect(JSON.parse(json)['@context']).toBe('https://example.test');
+  });
+});
+
+describe('script tag escaping', () => {
+  test('values containing </script> stay inside the script tag', () => {
+    const rendered = renderHead(JsonLd, {
+      schema: { '@type': 'Article', headline: 'Escape </script> test <b>not bold</b>' }
+    });
+
+    expect(rendered.jsonLd).toHaveLength(1);
+    expect(JSON.parse(rendered.jsonLd[0]).headline).toBe('Escape </script> test <b>not bold</b>');
+  });
+
+  test('every < is emitted as a \\u003c escape', () => {
+    const [json] = renderHead(JsonLd, { schema: { '@type': 'Article', headline: '<b>x</b>' } }).jsonLd;
+
+    expect(json).not.toContain('<');
+    expect(json).toContain('\\u003c');
+  });
+});
+
+describe('flexible schema shapes', () => {
+  test('preserves hyphenated keys such as query-input', () => {
+    const [json] = renderHead(JsonLd, {
+      schema: {
+        '@type': 'SearchAction',
+        target: 'https://example.test/search?query={search_term_string}',
+        'query-input': 'required name=search_term_string'
+      }
+    }).jsonLd;
+
+    expect(JSON.parse(json)['query-input']).toBe('required name=search_term_string');
+  });
+
+  test('preserves an array @type', () => {
+    const [json] = renderHead(JsonLd, { schema: { '@type': ['Article', 'BlogPosting'] } }).jsonLd;
+
+    expect(JSON.parse(json)['@type']).toEqual(['Article', 'BlogPosting']);
+  });
+
+  test('preserves nested actions', () => {
+    const [json] = renderHead(JsonLd, {
+      schema: {
+        '@type': 'WebSite',
+        url: 'https://example.test',
+        potentialAction: { '@type': 'SearchAction', target: 'https://example.test/s?q={q}', 'query-input': 'required' }
+      }
+    }).jsonLd;
+
+    expect(JSON.parse(json).potentialAction['@type']).toBe('SearchAction');
+  });
+});

--- a/packages/svelte-meta-tags/tests/metaTags/additionalTags.test.ts
+++ b/packages/svelte-meta-tags/tests/metaTags/additionalTags.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from 'vitest';
+import MetaTags from '$lib/MetaTags.svelte';
+import { links, metaContent, metaTags, renderHead } from '../helpers/head';
+
+describe('standard tags', () => {
+  test('renders description, canonical and keywords', () => {
+    const rendered = renderHead(MetaTags, {
+      description: 'Description',
+      canonical: 'https://a.test/',
+      keywords: ['first keyword', 'second keyword']
+    });
+
+    expect(metaContent(rendered, 'description')).toBe('Description');
+    expect(links(rendered, 'canonical')[0].attrs.href).toBe('https://a.test/');
+    expect(metaContent(rendered, 'keywords')).toBe('first keyword, second keyword');
+  });
+
+  test('renders no keywords tag for an empty array', () => {
+    expect(metaTags(renderHead(MetaTags, { keywords: [] }), 'keywords')).toHaveLength(0);
+  });
+
+  test('escapes values that would otherwise break out of the attribute', () => {
+    const rendered = renderHead(MetaTags, { description: 'He said "hi" & <left>' });
+
+    expect(metaContent(rendered, 'description')).toBe('He said "hi" & <left>');
+    expect(rendered.html).not.toContain('<left>');
+  });
+});
+
+describe('alternates', () => {
+  test('renders the mobile alternate', () => {
+    const rendered = renderHead(MetaTags, {
+      mobileAlternate: { media: 'only screen and (max-width: 640px)', href: 'https://m.a.test/' }
+    });
+
+    const [alternate] = links(rendered, 'alternate');
+
+    expect(alternate.attrs.media).toBe('only screen and (max-width: 640px)');
+    expect(alternate.attrs.href).toBe('https://m.a.test/');
+  });
+
+  test('renders one alternate per language', () => {
+    const rendered = renderHead(MetaTags, {
+      languageAlternates: [
+        { hrefLang: 'de-AT', href: 'https://de.a.test/' },
+        { hrefLang: 'fr-FR', href: 'https://fr.a.test/' }
+      ]
+    });
+
+    expect(links(rendered, 'alternate').map((link) => link.attrs.hreflang)).toEqual(['de-AT', 'fr-FR']);
+  });
+});
+
+describe('additionalMetaTags', () => {
+  test('renders a name/content pair', () => {
+    const rendered = renderHead(MetaTags, {
+      additionalMetaTags: [{ name: 'application-name', content: 'SvelteMetaTags' }]
+    });
+
+    expect(metaContent(rendered, 'application-name')).toBe('SvelteMetaTags');
+  });
+
+  test('renders a property/content pair', () => {
+    const rendered = renderHead(MetaTags, {
+      additionalMetaTags: [{ property: 'dc:creator', content: 'Jane Doe' }]
+    });
+
+    expect(metaContent(rendered, 'dc:creator')).toBe('Jane Doe');
+  });
+
+  test('emits httpEquiv as the http-equiv attribute', () => {
+    const rendered = renderHead(MetaTags, {
+      additionalMetaTags: [{ httpEquiv: 'x-ua-compatible', content: 'IE=edge; chrome=1' }]
+    });
+
+    const [tag] = rendered.tags.filter((candidate) => candidate.attrs['http-equiv'] !== undefined);
+
+    expect(tag.attrs['http-equiv']).toBe('x-ua-compatible');
+    expect(tag.attrs.content).toBe('IE=edge; chrome=1');
+    expect(tag.attrs.httpEquiv).toBeUndefined();
+  });
+});
+
+describe('additionalLinkTags', () => {
+  test('renders arbitrary link tags in order', () => {
+    const rendered = renderHead(MetaTags, {
+      additionalLinkTags: [
+        { rel: 'icon', href: '/favicon.ico' },
+        { rel: 'apple-touch-icon', href: '/touch-76.png', sizes: '76x76' },
+        { rel: 'apple-touch-icon', href: '/touch-120.png', sizes: '120x120' },
+        { rel: 'mask-icon', href: '/safari-pinned-tab.svg', color: '#193860' }
+      ]
+    });
+
+    expect(links(rendered, 'icon')[0].attrs.href).toBe('/favicon.ico');
+    expect(links(rendered, 'apple-touch-icon').map((link) => link.attrs.sizes)).toEqual(['76x76', '120x120']);
+    expect(links(rendered, 'mask-icon')[0].attrs.color).toBe('#193860');
+  });
+});

--- a/packages/svelte-meta-tags/tests/metaTags/openGraph.test.ts
+++ b/packages/svelte-meta-tags/tests/metaTags/openGraph.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from 'vitest';
+import MetaTags from '$lib/MetaTags.svelte';
+import { metaContent, metaContents, metaTags, renderHead } from '../helpers/head';
+
+describe('openGraph fallbacks', () => {
+  test('renders nothing when the openGraph prop is absent', () => {
+    const rendered = renderHead(MetaTags, { title: 'Home', description: 'Description', canonical: 'https://a.test/' });
+
+    expect(metaTags(rendered, 'og:title')).toHaveLength(0);
+    expect(metaTags(rendered, 'og:url')).toHaveLength(0);
+  });
+
+  test('emits og tags under the property attribute, not name', () => {
+    const [tag] = metaTags(renderHead(MetaTags, { openGraph: { title: 'OG Title' } }), 'og:title');
+
+    expect(tag.attrs.property).toBe('og:title');
+    expect(tag.attrs.name).toBeUndefined();
+  });
+
+  test('og:title falls back to the templated title', () => {
+    const rendered = renderHead(MetaTags, { title: 'Home', titleTemplate: '%s | MySite', openGraph: {} });
+
+    expect(metaContent(rendered, 'og:title')).toBe('Home | MySite');
+  });
+
+  test('og:description falls back to description', () => {
+    const rendered = renderHead(MetaTags, { description: 'Page Description', openGraph: {} });
+
+    expect(metaContent(rendered, 'og:description')).toBe('Page Description');
+  });
+
+  test('og:url falls back to canonical', () => {
+    const rendered = renderHead(MetaTags, { canonical: 'https://a.test/page', openGraph: {} });
+
+    expect(metaContent(rendered, 'og:url')).toBe('https://a.test/page');
+  });
+
+  test('explicit openGraph values win over the fallbacks', () => {
+    const rendered = renderHead(MetaTags, {
+      title: 'Page Title',
+      description: 'Page Description',
+      canonical: 'https://a.test/page',
+      openGraph: { title: 'OG Title', description: 'OG Description', url: 'https://a.test/og' }
+    });
+
+    expect(metaContent(rendered, 'og:title')).toBe('OG Title');
+    expect(metaContent(rendered, 'og:description')).toBe('OG Description');
+    expect(metaContent(rendered, 'og:url')).toBe('https://a.test/og');
+  });
+
+  test('lowercases og:type', () => {
+    expect(metaContent(renderHead(MetaTags, { openGraph: { type: 'Website' } }), 'og:type')).toBe('website');
+  });
+});
+
+describe('openGraph images', () => {
+  test('renders every field of an image', () => {
+    const rendered = renderHead(MetaTags, {
+      openGraph: {
+        images: [
+          {
+            url: 'https://a.test/og.jpg',
+            alt: 'Og Image Alt',
+            width: 800,
+            height: 600,
+            secureUrl: 'https://a.test/og.jpg',
+            type: 'image/jpeg'
+          }
+        ]
+      }
+    });
+
+    expect(metaContent(rendered, 'og:image')).toBe('https://a.test/og.jpg');
+    expect(metaContent(rendered, 'og:image:alt')).toBe('Og Image Alt');
+    expect(metaContent(rendered, 'og:image:width')).toBe('800');
+    expect(metaContent(rendered, 'og:image:height')).toBe('600');
+    expect(metaContent(rendered, 'og:image:secure_url')).toBe('https://a.test/og.jpg');
+    expect(metaContent(rendered, 'og:image:type')).toBe('image/jpeg');
+  });
+
+  test('image (singular) is prepended to images', () => {
+    const rendered = renderHead(MetaTags, {
+      openGraph: {
+        image: { url: 'https://a.test/primary.jpg', alt: 'Primary image' },
+        images: [{ url: 'https://a.test/second.jpg', alt: 'Second image' }]
+      }
+    });
+
+    expect(metaContents(rendered, 'og:image')).toEqual(['https://a.test/primary.jpg', 'https://a.test/second.jpg']);
+    expect(metaContents(rendered, 'og:image:alt')).toEqual(['Primary image', 'Second image']);
+  });
+
+  test('image alone renders as a single og:image', () => {
+    const rendered = renderHead(MetaTags, { openGraph: { image: { url: 'https://a.test/only.jpg' } } });
+
+    expect(metaContents(rendered, 'og:image')).toEqual(['https://a.test/only.jpg']);
+  });
+
+  test('renders no og:image when neither is set', () => {
+    expect(metaTags(renderHead(MetaTags, { openGraph: { title: 'OG' } }), 'og:image')).toHaveLength(0);
+  });
+});
+
+describe('openGraph videos and audio', () => {
+  test('renders every field of a video', () => {
+    const rendered = renderHead(MetaTags, {
+      openGraph: {
+        videos: [
+          {
+            url: 'https://a.test/og.mp4',
+            width: 800,
+            height: 600,
+            secureUrl: 'https://a.test/og.mp4',
+            type: 'video/mp4'
+          }
+        ]
+      }
+    });
+
+    expect(metaContent(rendered, 'og:video')).toBe('https://a.test/og.mp4');
+    expect(metaContent(rendered, 'og:video:width')).toBe('800');
+    expect(metaContent(rendered, 'og:video:height')).toBe('600');
+    expect(metaContent(rendered, 'og:video:secure_url')).toBe('https://a.test/og.mp4');
+    expect(metaContent(rendered, 'og:video:type')).toBe('video/mp4');
+  });
+
+  test('renders every field of an audio entry', () => {
+    const rendered = renderHead(MetaTags, {
+      openGraph: {
+        audio: [{ url: 'https://a.test/og.mp3', secureUrl: 'https://a.test/og.mp3', type: 'audio/mp3' }]
+      }
+    });
+
+    expect(metaContent(rendered, 'og:audio')).toBe('https://a.test/og.mp3');
+    expect(metaContent(rendered, 'og:audio:secure_url')).toBe('https://a.test/og.mp3');
+    expect(metaContent(rendered, 'og:audio:type')).toBe('audio/mp3');
+  });
+
+  test('renders locale and siteName', () => {
+    const rendered = renderHead(MetaTags, { openGraph: { locale: 'en_IE', siteName: 'SiteName' } });
+
+    expect(metaContent(rendered, 'og:locale')).toBe('en_IE');
+    expect(metaContent(rendered, 'og:site_name')).toBe('SiteName');
+  });
+});
+
+describe('facebook', () => {
+  test('renders fb:app_id when appId is set', () => {
+    expect(metaContent(renderHead(MetaTags, { facebook: { appId: '1234567890' } }), 'fb:app_id')).toBe('1234567890');
+  });
+
+  test('renders no fb:app_id when facebook is an empty object', () => {
+    expect(metaTags(renderHead(MetaTags, { facebook: {} }), 'fb:app_id')).toHaveLength(0);
+  });
+});

--- a/packages/svelte-meta-tags/tests/metaTags/openGraphType.test.ts
+++ b/packages/svelte-meta-tags/tests/metaTags/openGraphType.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from 'vitest';
+import MetaTags from '$lib/MetaTags.svelte';
+import { metaContent, metaContents, metaTags, renderHead } from '../helpers/head';
+
+describe('og:type profile', () => {
+  test('renders every profile field', () => {
+    const rendered = renderHead(MetaTags, {
+      openGraph: {
+        type: 'profile',
+        profile: { firstName: 'First', lastName: 'Last', username: 'user', gender: 'female' }
+      }
+    });
+
+    expect(metaContent(rendered, 'profile:first_name')).toBe('First');
+    expect(metaContent(rendered, 'profile:last_name')).toBe('Last');
+    expect(metaContent(rendered, 'profile:username')).toBe('user');
+    expect(metaContent(rendered, 'profile:gender')).toBe('female');
+  });
+
+  test('renders no profile fields when the profile object is missing', () => {
+    const rendered = renderHead(MetaTags, { openGraph: { type: 'profile' } });
+
+    expect(metaContent(rendered, 'og:type')).toBe('profile');
+    expect(metaTags(rendered, 'profile:first_name')).toHaveLength(0);
+  });
+});
+
+describe('og:type book', () => {
+  test('renders every book field, repeating authors and tags', () => {
+    const rendered = renderHead(MetaTags, {
+      openGraph: {
+        type: 'book',
+        book: {
+          authors: ['https://a.test/authors/a', 'https://a.test/authors/b'],
+          isbn: '978-3-16-148410-0',
+          releaseDate: '2018-09-17T11:08:13Z',
+          tags: ['Tag A', 'Tag B']
+        }
+      }
+    });
+
+    expect(metaContents(rendered, 'book:author')).toEqual(['https://a.test/authors/a', 'https://a.test/authors/b']);
+    expect(metaContent(rendered, 'book:isbn')).toBe('978-3-16-148410-0');
+    expect(metaContent(rendered, 'book:release_date')).toBe('2018-09-17T11:08:13Z');
+    expect(metaContents(rendered, 'book:tag')).toEqual(['Tag A', 'Tag B']);
+  });
+
+  test('tolerates a book without authors or tags', () => {
+    const rendered = renderHead(MetaTags, { openGraph: { type: 'book', book: { isbn: '1' } } });
+
+    expect(metaContent(rendered, 'book:isbn')).toBe('1');
+    expect(metaTags(rendered, 'book:author')).toHaveLength(0);
+  });
+});
+
+describe('og:type article', () => {
+  test('renders every article field, repeating authors and tags', () => {
+    const rendered = renderHead(MetaTags, {
+      openGraph: {
+        type: 'article',
+        article: {
+          publishedTime: '2021-01-01T00:00:00Z',
+          modifiedTime: '2021-02-01T00:00:00Z',
+          expirationTime: '2022-01-01T00:00:00Z',
+          authors: ['https://a.test/authors/a'],
+          section: 'Section II',
+          tags: ['Tag A', 'Tag B']
+        }
+      }
+    });
+
+    expect(metaContent(rendered, 'article:published_time')).toBe('2021-01-01T00:00:00Z');
+    expect(metaContent(rendered, 'article:modified_time')).toBe('2021-02-01T00:00:00Z');
+    expect(metaContent(rendered, 'article:expiration_time')).toBe('2022-01-01T00:00:00Z');
+    expect(metaContents(rendered, 'article:author')).toEqual(['https://a.test/authors/a']);
+    expect(metaContent(rendered, 'article:section')).toBe('Section II');
+    expect(metaContents(rendered, 'article:tag')).toEqual(['Tag A', 'Tag B']);
+  });
+});
+
+describe('og:type video', () => {
+  const video = {
+    actors: [
+      { profile: 'https://a.test/actors/a', role: 'Protagonist' },
+      { profile: 'https://a.test/actors/b', role: 'Antagonist' }
+    ],
+    directors: ['https://a.test/directors/a'],
+    writers: ['https://a.test/writers/a'],
+    duration: 680000,
+    releaseDate: '2022-12-21T22:04:11Z',
+    tags: ['Tag A'],
+    series: 'The Example Series'
+  };
+
+  test('renders every video field for video.movie', () => {
+    const rendered = renderHead(MetaTags, { openGraph: { type: 'video.movie', video } });
+
+    expect(metaContents(rendered, 'video:actor')).toEqual(['https://a.test/actors/a', 'https://a.test/actors/b']);
+    expect(metaContents(rendered, 'video:actor:role')).toEqual(['Protagonist', 'Antagonist']);
+    expect(metaContents(rendered, 'video:director')).toEqual(['https://a.test/directors/a']);
+    expect(metaContents(rendered, 'video:writer')).toEqual(['https://a.test/writers/a']);
+    expect(metaContent(rendered, 'video:duration')).toBe('680000');
+    expect(metaContent(rendered, 'video:release_date')).toBe('2022-12-21T22:04:11Z');
+    expect(metaContents(rendered, 'video:tag')).toEqual(['Tag A']);
+    expect(metaContent(rendered, 'video:series')).toBe('The Example Series');
+  });
+
+  test.each(['video.episode', 'video.tv_show', 'video.other'])('renders the video block for %s', (type) => {
+    const rendered = renderHead(MetaTags, { openGraph: { type, video } });
+
+    expect(metaContent(rendered, 'og:type')).toBe(type);
+    expect(metaContent(rendered, 'video:series')).toBe('The Example Series');
+  });
+
+  test('renders a partial video block', () => {
+    const rendered = renderHead(MetaTags, {
+      openGraph: { type: 'video.other', video: { directors: ['https://a.test/directors/a'], series: 'The Series' } }
+    });
+
+    expect(metaContents(rendered, 'video:director')).toEqual(['https://a.test/directors/a']);
+    expect(metaContent(rendered, 'video:series')).toBe('The Series');
+    expect(metaTags(rendered, 'video:actor')).toHaveLength(0);
+  });
+
+  test('video.other without a video object renders no video fields', () => {
+    const rendered = renderHead(MetaTags, { openGraph: { type: 'video.other' } });
+
+    expect(metaContent(rendered, 'og:type')).toBe('video.other');
+    expect(metaTags(rendered, 'video:series')).toHaveLength(0);
+  });
+
+  // The guard for video.movie / video.episode / video.tv_show does not require
+  // `openGraph.video`, unlike the one for video.other. This locks in that the
+  // asymmetry is at least survivable.
+  test.each(['video.movie', 'video.episode', 'video.tv_show'])(
+    '%s without a video object renders no video fields',
+    (type) => {
+      const rendered = renderHead(MetaTags, { openGraph: { type } });
+
+      expect(metaContent(rendered, 'og:type')).toBe(type);
+      expect(metaTags(rendered, 'video:series')).toHaveLength(0);
+    }
+  );
+});
+
+describe('og:type dispatch', () => {
+  test('an unknown type renders og:type only', () => {
+    const rendered = renderHead(MetaTags, { openGraph: { type: 'music.song' } });
+
+    expect(metaContent(rendered, 'og:type')).toBe('music.song');
+    expect(rendered.tags.filter((tag) => tag.attrs.property?.startsWith('music:'))).toHaveLength(0);
+  });
+
+  test('type matching is case-insensitive', () => {
+    const rendered = renderHead(MetaTags, { openGraph: { type: 'Article', article: { section: 'Section II' } } });
+
+    expect(metaContent(rendered, 'og:type')).toBe('article');
+    expect(metaContent(rendered, 'article:section')).toBe('Section II');
+  });
+});

--- a/packages/svelte-meta-tags/tests/metaTags/render.bench.ts
+++ b/packages/svelte-meta-tags/tests/metaTags/render.bench.ts
@@ -1,0 +1,74 @@
+import { bench, describe } from 'vitest';
+import { render } from 'svelte/server';
+import MetaTags from '$lib/MetaTags.svelte';
+import JsonLd from '$lib/JsonLd.svelte';
+
+/**
+ * Server-render cost of the components. This is the number that matters when
+ * judging whether a change to MetaTags is expensive — a difference that does
+ * not show up here is not worth trading readability for.
+ */
+
+const minimal = { title: 'Home', description: 'Description' };
+
+const typical = {
+  title: 'Home',
+  titleTemplate: '%s | MySite',
+  description: 'Description',
+  canonical: 'https://a.test/',
+  keywords: ['a', 'b'],
+  twitter: { cardType: 'summary_large_image', site: '@site', creator: '@handle' },
+  facebook: { appId: '123' },
+  openGraph: {
+    type: 'article',
+    article: { publishedTime: '2021-01-01T00:00:00Z', authors: ['https://a.test/a'], tags: ['x', 'y'] },
+    images: [{ url: 'https://a.test/og.jpg', alt: 'alt', width: 1200, height: 630 }],
+    locale: 'en_IE',
+    siteName: 'SiteName'
+  },
+  additionalLinkTags: [{ rel: 'icon', href: '/favicon.ico' }]
+};
+
+const everyRobotsDirective = {
+  ...typical,
+  additionalRobotsProps: {
+    nosnippet: true,
+    notranslate: true,
+    noimageindex: true,
+    noarchive: true,
+    unavailableAfter: '2030-12-31',
+    maxSnippet: -1,
+    maxImagePreview: 'none',
+    maxVideoPreview: -1
+  }
+};
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const run = (component: any, props: unknown) => render(component, { props } as any);
+
+describe('MetaTags server render', () => {
+  bench('minimal props', () => {
+    run(MetaTags, minimal);
+  });
+
+  bench('typical page', () => {
+    run(MetaTags, typical);
+  });
+
+  bench('every robots directive', () => {
+    run(MetaTags, everyRobotsDirective);
+  });
+});
+
+describe('JsonLd server render', () => {
+  bench('single schema', () => {
+    run(JsonLd, { schema: { '@type': 'Article', headline: 'Headline' } });
+  });
+
+  bench('graph of ten', () => {
+    run(JsonLd, {
+      schema: { '@graph': Array.from({ length: 10 }, (_, i) => ({ '@type': 'Article', headline: `Headline ${i}` })) }
+    });
+  });
+});
+/* eslint-enable @typescript-eslint/no-explicit-any */

--- a/packages/svelte-meta-tags/tests/metaTags/robots.test.ts
+++ b/packages/svelte-meta-tags/tests/metaTags/robots.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'vitest';
+import MetaTags from '$lib/MetaTags.svelte';
+import { metaContent, metaTags, renderHead } from '../helpers/head';
+
+describe('robots', () => {
+  test('defaults to index,follow when nothing is passed', () => {
+    expect(metaContent(renderHead(MetaTags, {}), 'robots')).toBe('index,follow');
+  });
+
+  test('uses the supplied directive', () => {
+    expect(metaContent(renderHead(MetaTags, { robots: 'noindex,nofollow' }), 'robots')).toBe('noindex,nofollow');
+  });
+
+  test('suppresses the tag entirely when robots is false', () => {
+    expect(metaTags(renderHead(MetaTags, { robots: false }), 'robots')).toHaveLength(0);
+  });
+
+  test('appends every additional prop in a fixed order', () => {
+    const rendered = renderHead(MetaTags, {
+      additionalRobotsProps: {
+        nosnippet: true,
+        notranslate: true,
+        noimageindex: true,
+        noarchive: true,
+        unavailableAfter: '2030-12-31',
+        maxSnippet: -1,
+        maxImagePreview: 'none',
+        maxVideoPreview: -1
+      }
+    });
+
+    expect(metaContent(rendered, 'robots')).toBe(
+      'index,follow,nosnippet,max-snippet:-1,max-image-preview:none,noarchive,unavailable_after:2030-12-31,noimageindex,max-video-preview:-1,notranslate'
+    );
+  });
+
+  test('omits props that are not set', () => {
+    const rendered = renderHead(MetaTags, { additionalRobotsProps: { noarchive: true, maxImagePreview: 'large' } });
+
+    expect(metaContent(rendered, 'robots')).toBe('index,follow,max-image-preview:large,noarchive');
+  });
+
+  test('appends additional props to a custom directive', () => {
+    const rendered = renderHead(MetaTags, { robots: 'noindex', additionalRobotsProps: { nosnippet: true } });
+
+    expect(metaContent(rendered, 'robots')).toBe('noindex,nosnippet');
+  });
+
+  test('drops falsy numeric props — max-snippet:0 is currently unreachable', () => {
+    const rendered = renderHead(MetaTags, { additionalRobotsProps: { maxSnippet: 0, maxVideoPreview: 0 } });
+
+    expect(metaContent(rendered, 'robots')).toBe('index,follow');
+  });
+
+  test('boolean props set to false are omitted', () => {
+    const rendered = renderHead(MetaTags, { additionalRobotsProps: { nosnippet: false, noarchive: true } });
+
+    expect(metaContent(rendered, 'robots')).toBe('index,follow,noarchive');
+  });
+});

--- a/packages/svelte-meta-tags/tests/metaTags/title.test.ts
+++ b/packages/svelte-meta-tags/tests/metaTags/title.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'vitest';
+import MetaTags from '$lib/MetaTags.svelte';
+import { renderHead } from '../helpers/head';
+
+describe('title and titleTemplate', () => {
+  test('renders the title as given when no template is set', () => {
+    expect(renderHead(MetaTags, { title: 'Home' }).title).toBe('Home');
+  });
+
+  test('substitutes %s with the title', () => {
+    expect(renderHead(MetaTags, { title: 'Home', titleTemplate: '%s | MySite' }).title).toBe('Home | MySite');
+  });
+
+  test('substitutes every %s occurrence', () => {
+    expect(renderHead(MetaTags, { title: 'Home', titleTemplate: '%s — %s' }).title).toBe('Home — Home');
+  });
+
+  test('inserts titles containing $& literally rather than as a replacement pattern', () => {
+    expect(renderHead(MetaTags, { title: 'Rock $& Roll', titleTemplate: '%s | MySite' }).title).toBe(
+      'Rock $& Roll | MySite'
+    );
+  });
+
+  test("inserts titles containing $` and $' literally", () => {
+    expect(renderHead(MetaTags, { title: "a $` b $' c", titleTemplate: '%s | MySite' }).title).toBe(
+      "a $` b $' c | MySite"
+    );
+  });
+
+  test('renders no title when title is missing, even with a template', () => {
+    expect(renderHead(MetaTags, { titleTemplate: '%s | MySite' }).title).toBeUndefined();
+  });
+
+  test('renders no title when neither is set', () => {
+    expect(renderHead(MetaTags, {}).title).toBeUndefined();
+  });
+});

--- a/packages/svelte-meta-tags/tests/metaTags/twitter.test.ts
+++ b/packages/svelte-meta-tags/tests/metaTags/twitter.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from 'vitest';
+import MetaTags from '$lib/MetaTags.svelte';
+import { metaContent, metaTags, renderHead } from '../helpers/head';
+
+describe('twitter', () => {
+  test('renders nothing when the twitter prop is absent', () => {
+    const rendered = renderHead(MetaTags, { title: 'Home', description: 'Description' });
+
+    expect(metaTags(rendered, 'twitter:title')).toHaveLength(0);
+    expect(metaTags(rendered, 'twitter:description')).toHaveLength(0);
+  });
+
+  test('emits twitter tags under the name attribute, not property', () => {
+    const [tag] = metaTags(renderHead(MetaTags, { twitter: { cardType: 'summary' } }), 'twitter:card');
+
+    expect(tag.attrs.name).toBe('twitter:card');
+    expect(tag.attrs.property).toBeUndefined();
+  });
+
+  test('stringifies numeric player dimensions', () => {
+    const rendered = renderHead(MetaTags, { twitter: { playerWidth: 435, playerHeight: 251 } });
+
+    expect(metaContent(rendered, 'twitter:player:width')).toBe('435');
+    expect(metaContent(rendered, 'twitter:player:height')).toBe('251');
+  });
+
+  test('renders the full app card surface', () => {
+    const rendered = renderHead(MetaTags, {
+      twitter: {
+        cardType: 'app',
+        appNameIphone: 'App iPhone',
+        appIdIphone: '111',
+        appUrlIphone: 'https://example.com/iphone',
+        appNameIpad: 'App iPad',
+        appIdIpad: '222',
+        appUrlIpad: 'https://example.com/ipad',
+        appNameGoogleplay: 'App Play',
+        appIdGoogleplay: '333',
+        appUrlGoogleplay: 'https://example.com/play'
+      }
+    });
+
+    expect(metaContent(rendered, 'twitter:app:name:iphone')).toBe('App iPhone');
+    expect(metaContent(rendered, 'twitter:app:id:ipad')).toBe('222');
+    expect(metaContent(rendered, 'twitter:app:url:googleplay')).toBe('https://example.com/play');
+  });
+});
+
+describe('twitter fallback chain', () => {
+  test('falls back to OpenGraph values', () => {
+    const rendered = renderHead(MetaTags, {
+      title: 'Page Title',
+      description: 'Page Description',
+      twitter: { cardType: 'summary_large_image', site: '@site' },
+      openGraph: { title: 'OG Title', description: 'OG Description' }
+    });
+
+    expect(metaContent(rendered, 'twitter:title')).toBe('OG Title');
+    expect(metaContent(rendered, 'twitter:description')).toBe('OG Description');
+  });
+
+  test('falls back to the standard values when OpenGraph is absent', () => {
+    const rendered = renderHead(MetaTags, {
+      title: 'Page Title',
+      description: 'Page Description',
+      twitter: { cardType: 'summary' }
+    });
+
+    expect(metaContent(rendered, 'twitter:title')).toBe('Page Title');
+    expect(metaContent(rendered, 'twitter:description')).toBe('Page Description');
+  });
+
+  test('explicit twitter values win over both fallbacks', () => {
+    const rendered = renderHead(MetaTags, {
+      title: 'Page Title',
+      description: 'Page Description',
+      twitter: { title: 'Twitter Title', description: 'Twitter Description' },
+      openGraph: { title: 'OG Title', description: 'OG Description' }
+    });
+
+    expect(metaContent(rendered, 'twitter:title')).toBe('Twitter Title');
+    expect(metaContent(rendered, 'twitter:description')).toBe('Twitter Description');
+  });
+
+  test('falls back independently per field', () => {
+    const rendered = renderHead(MetaTags, {
+      title: 'Page Title',
+      description: 'Page Description',
+      twitter: { cardType: 'summary' },
+      openGraph: { title: 'OG Title' }
+    });
+
+    expect(metaContent(rendered, 'twitter:title')).toBe('OG Title');
+    expect(metaContent(rendered, 'twitter:description')).toBe('Page Description');
+  });
+
+  test('the title fallback uses the templated title', () => {
+    const rendered = renderHead(MetaTags, {
+      title: 'Home',
+      titleTemplate: '%s | MySite',
+      description: 'Page Description',
+      twitter: { cardType: 'summary' }
+    });
+
+    expect(metaContent(rendered, 'twitter:title')).toBe('Home | MySite');
+  });
+});

--- a/packages/svelte-meta-tags/tests/robots/robots.bench.ts
+++ b/packages/svelte-meta-tags/tests/robots/robots.bench.ts
@@ -1,0 +1,34 @@
+import { bench, describe } from 'vitest';
+import { serializeRobots } from '$lib/robots';
+import type { AdditionalRobotsProps } from '$lib/types';
+
+const two: AdditionalRobotsProps = { noarchive: true, maxImagePreview: 'large' };
+
+const all: AdditionalRobotsProps = {
+  nosnippet: true,
+  notranslate: true,
+  noimageindex: true,
+  noarchive: true,
+  unavailableAfter: '2030-12-31',
+  maxSnippet: -1,
+  maxImagePreview: 'none',
+  maxVideoPreview: -1
+};
+
+describe('serializeRobots', () => {
+  bench('no additional props', () => {
+    serializeRobots('index,follow', undefined);
+  });
+
+  bench('two directives', () => {
+    serializeRobots('index,follow', two);
+  });
+
+  bench('all eight directives', () => {
+    serializeRobots('index,follow', all);
+  });
+
+  bench('robots false', () => {
+    serializeRobots(false, all);
+  });
+});

--- a/packages/svelte-meta-tags/tests/robots/robots.test.ts
+++ b/packages/svelte-meta-tags/tests/robots/robots.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'vitest';
+import { serializeRobots } from '$lib/robots';
+
+describe('serializeRobots', () => {
+  test('returns null when robots is false', () => {
+    expect(serializeRobots(false, undefined)).toBeNull();
+    expect(serializeRobots(false, { nosnippet: true })).toBeNull();
+  });
+
+  test('returns the directive unchanged when there are no additional props', () => {
+    expect(serializeRobots('index,follow', undefined)).toBe('index,follow');
+    expect(serializeRobots('noindex,nofollow', undefined)).toBe('noindex,nofollow');
+  });
+
+  test('returns the directive unchanged for an empty additional props object', () => {
+    expect(serializeRobots('index,follow', {})).toBe('index,follow');
+  });
+
+  test('appends directives in the documented order regardless of key order', () => {
+    expect(
+      serializeRobots('index,follow', {
+        notranslate: true,
+        maxVideoPreview: -1,
+        noimageindex: true,
+        unavailableAfter: '2030-12-31',
+        noarchive: true,
+        maxImagePreview: 'none',
+        maxSnippet: -1,
+        nosnippet: true
+      })
+    ).toBe(
+      'index,follow,nosnippet,max-snippet:-1,max-image-preview:none,noarchive,unavailable_after:2030-12-31,noimageindex,max-video-preview:-1,notranslate'
+    );
+  });
+
+  test('drops falsy values', () => {
+    expect(serializeRobots('index,follow', { nosnippet: false, maxSnippet: 0, maxVideoPreview: 0 })).toBe(
+      'index,follow'
+    );
+  });
+
+  test('renders a tag for robots true', () => {
+    expect(serializeRobots(true, undefined)).toBe('true');
+  });
+});

--- a/tests/svelte-5/package.json
+++ b/tests/svelte-5/package.json
@@ -7,7 +7,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-    "test": "playwright test"
+    "test": "svelte-kit sync && playwright test"
   },
   "devDependencies": {
     "@playwright/test": "catalog:",


### PR DESCRIPTION
## Why

Every behavior of `<MetaTags>` and `<JsonLd>` was only reachable through Playwright driving a built SvelteKit preview. A fallback-precedence assertion cost a fixture route, a spec file and a browser round-trip — 29 routes and 25 specs, 1,827 LOC, gated behind `vite build`.

`render()` from `svelte/server` returns the head markup directly. Same assertions, ~50 ms for the whole suite, no build and no browser.

## What changed

**`test:` — in-process rendering tests (078ad16)**

- `packages/svelte-meta-tags/tests/helpers/head.ts` — `renderHead` / `renderBody` return `{ title, tags, jsonLd, html }`; `metaContent`, `metaContents`, `metaTags` and `links` read tags back out.
- 79 tests across `tests/metaTags/` and `tests/jsonLd/`: the Twitter and OpenGraph fallback chains, `titleTemplate` substitution, robots serialization, all four `og:type` sub-blocks, the `openGraph.image` alias, `http-equiv` emission, and the JSON-LD `@context` injection and `<` escaping.

The attribute scanner is quote-aware on purpose — Svelte escapes `<` to `&lt;` inside attribute values but leaves `>` raw, so matching up to the first `>` cuts values short. That bit me while writing it.

**`refactor:` — robots serialization module (0ac2db8)**

Robots policy was spread across three sites in `MetaTags.svelte`: a six-line nested template literal, an `$effect` warning, and a `{#if robots !== false}` guard. `serializeRobots()` now returns the content string or `null` when no tag should render, and the directive order lives in an explicit `DIRECTIVES` table rather than being implied by the shape of a template literal. `MetaTags.svelte` loses 27 lines.

The warning stays in the `$effect` — calling `console.warn` from a pure function reached via `$derived` would fire on every server render and put a side effect inside a derived. Only the message string moved.

**`docs:` — changeset and test strategy (21767bc)**

The refactor changes the published package, so it gets a `patch` changeset:

```
dist/robots.js       1.3 kB   new
dist/robots.d.ts     556 B    new
dist/MetaTags.svelte          now imports './robots' at runtime
```

`svelte-meta-tags/robots` is not in `exports`, so the module stays internal — importing it fails with `ERR_PACKAGE_PATH_NOT_EXPORTED`. No public API moved.

`CONTRIBUTING.md` still said *"End to end tests are required for all changes and new features"*, which no longer matches how the suite is layered. It now has a **Testing** section describing both layers and where a test belongs:

- **Vitest is the default**, including for the components — `.ts` modules are called directly, and `<MetaTags>` / `<JsonLd>` are rendered in process and their markup asserted. Adding a tag, changing a fallback chain or fixing an escaping bug needs a test here and usually nothing else.
- **Playwright only when the browser matters** — `$effect` does not run during server rendering, plus client-side navigation and a smoke check that tags reach `<head>` for real.

Also adds a test over the public entry point, so an accidental export change fails in Vitest rather than downstream.

**`ci:` — `svelte-kit sync` before `playwright test` (972c64f)**

Pre-existing commit on this branch, included because without it `pnpm test` cannot start at all. Playwright 1.62.0 resolves the tsconfig next to the config file, and `tests/svelte-5/tsconfig.json` extends the not-yet-generated `./.svelte-kit/tsconfig.json`. Happy to split it out if you'd rather review it separately.

## Verification

| Gate | Result |
| --- | --- |
| `pnpm lint` | pass |
| `pnpm check` | 0 errors, 0 warnings |
| `pnpm package` | publint clean |
| `vitest` (lib) | **128 passed** (was 39), 52 ms |
| `playwright --project=chromium` | **29 passed**, unmodified |

All 29 e2e tests pass untouched, including `robotsAnother.test.ts` which asserts the `console.warn` still fires — the refactor is behavior-preserving.

Firefox and WebKit were not run locally (browser binaries not installed); CI covers the full matrix.

## Two things worth a look, not fixed here

- **`maxSnippet: 0` is unreachable.** Directives are filtered on truthiness, so `max-snippet:0` — a valid directive — is dropped. Locked in as current behavior in `tests/robots/robots.test.ts`; changing it is a spec decision.
- **`og:type` guard asymmetry.** `video.other` requires `openGraph.video`, but `video.movie` / `video.episode` / `video.tv_show` do not. Not a crash (tests confirm the block renders empty), but the arms disagree.

## Follow-up

The e2e suite still asserts tag-by-tag, which now duplicates the Vitest layer. Trimming it to smoke coverage is a separate PR — deleting tests deserves its own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent robots metadata serialization with ordered directives, custom extensions, and support for disabling the tag.
  * Expanded metadata rendering coverage for titles, Open Graph, Twitter cards, JSON-LD, links, and standard meta tags.
* **Bug Fixes**
  * Improved robots metadata handling for empty and falsy values.
  * Preserved correct escaping, fallbacks, and attribute formatting across generated metadata.
* **Tests**
  * Added comprehensive in-process rendering and browser test coverage.
* **Documentation**
  * Clarified testing workflows and robots metadata behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->