### PR TITLE
docs: drop stale note about vendored skills in `--list` output

### DIFF
--- a/docs/content/guides/agent-skills.md
+++ b/docs/content/guides/agent-skills.md
@@ -33,5 +33,3 @@ To list every skill the CLI can find in the repo, run:
 ```sh
 npx skills add oekazuma/svelte-meta-tags --list
 ```
-
-Note that `--list` also picks up skills this repository vendors from other projects for its own development (under `.agents/skills/`) — the two skills above are the ones svelte-meta-tags itself provides.

--- a/docs/content/ja/guides/agent-skills.md
+++ b/docs/content/ja/guides/agent-skills.md
@@ -33,5 +33,3 @@ CLI がリポジトリ内で見つけられるスキルの一覧を確認する�
 ```sh
 npx skills add oekazuma/svelte-meta-tags --list
 ```
-
-なお `--list` には、このリポジトリが開発用に他プロジェクトから取り込んでいるスキル（`.agents/skills/` 配下）も表示されます。svelte-meta-tags 自体が提供するスキルは上記の2つです。


### PR DESCRIPTION
## Summary

`docs/content/guides/agent-skills.md` (and its ja translation) warned that `npx skills add oekazuma/svelte-meta-tags --list` also surfaces the skills this repo vendors for its own development (`.agents/skills/svelte-code-writer`, `svelte-core-bestpractices`). That is no longer true, so the note is removed from both locales.

The skills CLI skips vendored skills — those whose name appears in the root `skills-lock.json` and which live under an agent skill dir such as `.agents/skills/` — since vercel-labs/skills#1281 ("Ignore vendored skills in packages, to prevent duplicate installations"). Our layout already matches that condition, so no repo-side change is needed.

## Verification

```
$ npx skills@latest add <repo> --list
◇  Found 2 skills
     svelte-meta-tags-companion
     svelte-meta-tags-setup
```

`prettier --check` passes on both files. Docs-only change, so no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified the Agent Skills guide in English and Japanese by removing an explanatory note about development-only skills shown by the listing command.
  * No other documentation content was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->