### PR TITLE
docs: cover the install step and the silent no-ops in the Agent Skills

### DIFF
--- a/skills/svelte-meta-tags-companion/SKILL.md
+++ b/skills/svelte-meta-tags-companion/SKILL.md
@@ -52,7 +52,7 @@ import { deepMerge } from 'svelte-meta-tags';
 const metaTags = deepMerge(baseMetaTags, pageMetaTags);
 ```
 
-`deepMerge` correctly merges nested objects (like `openGraph` itself — its individual fields such as `title` or `description` merge independently rather than one override replacing the whole object), replaces arrays instead of concatenating them (e.g. `openGraph.images`), and has defined precedence rules for `Date`/function values. A shallow spread silently drops nested overrides; third-party merge libraries don't know about these library-specific rules.
+`deepMerge` correctly merges nested objects (like `openGraph` itself — its individual fields such as `title` or `description` merge independently rather than one override replacing the whole object), replaces arrays instead of concatenating them (e.g. `openGraph.images`), and keeps a `Date` or function already on the **target** rather than letting the source overwrite it — the reverse of its usual source-wins rule. A shallow spread silently drops nested overrides; third-party merge libraries don't know about these library-specific rules.
 
 ### 3. Spreading the wrong prop into `<MetaTags>`
 
@@ -72,6 +72,70 @@ const twitterTitle = twitter?.title ?? openGraph?.title ?? title;
 ```
 
 `<MetaTags>` already falls back `twitter.title → openGraph.title → title` (using the title with `titleTemplate` applied, and the same shape for `description`) — don't compute this yourself before passing props in.
+
+### 5. Passing more than two objects to `deepMerge`
+
+```ts
+// ❌ Wrong: deepMerge takes exactly (target, source) — the third argument is ignored, silently
+const metaTags = deepMerge(siteMetaTags, sectionMetaTags, pageMetaTags);
+
+// ✅ Correct: chain it
+const metaTags = deepMerge(deepMerge(siteMetaTags, sectionMetaTags), pageMetaTags);
+```
+
+TypeScript flags the extra argument, so this only slips through in a `.svelte` file without `lang="ts"` — which is exactly where layout wiring tends to live.
+
+Note also that `deepMerge` iterates the source with `Object.entries`, so **symbol keys on the source are dropped**. Meta tag props are string-keyed, so this only matters if you are merging your own data through the same helper.
+
+## Why a tag isn't rendering
+
+These are not wrong code — they are correct-looking props that produce no output. Check them before assuming a bug in the library.
+
+### `og:*` and `twitter:*` need their prop object to exist at all
+
+```svelte
+<!-- ❌ No og:title / og:description is rendered — the whole openGraph block is skipped -->
+<MetaTags title="My Page" description="A short description." />
+
+<!-- ✅ og:title falls back to the (templated) title, og:description to description -->
+<MetaTags title="My Page" description="A short description." openGraph={{}} />
+```
+
+`<MetaTags>` guards the entire OpenGraph block behind `{#if openGraph}` and the Twitter block behind `{#if twitter}`. The documented fallbacks (`og:title` → `title`, `twitter.title` → `openGraph.title` → `title`) only apply _inside_ those blocks, so a page that sets just `title` and `description` emits no social tags at all.
+
+### `titleTemplate` alone renders no `<title>`
+
+```svelte
+<!-- ❌ No <title> at all — the template is not applied on its own -->
+<MetaTags titleTemplate="%s | My Site" description="About us." />
+```
+
+When `title` is missing, `<MetaTags>` skips the `<title>` element entirely rather than rendering the bare template. A base layout that sets only `titleTemplate` therefore produces no title on any page that forgets its own — give the base layout a `title` too, so the merged result always has one.
+
+### Falsy `additionalRobotsProps` values are dropped
+
+```svelte
+<!-- ❌ Emits nothing: 0 is falsy, so the directive is skipped -->
+<MetaTags additionalRobotsProps={{ maxSnippet: 0 }} />
+
+<!-- ✅ -1 is truthy and renders as max-snippet:-1 -->
+<MetaTags additionalRobotsProps={{ maxSnippet: -1 }} />
+```
+
+Every directive is included only when its value is truthy. `-1` (the "no limit" value for `maxSnippet` and `maxVideoPreview`) works; `0` does not.
+
+### `robots={false}` suppresses the tag, and `additionalRobotsProps` with it
+
+Setting `robots={false}` removes `<meta name="robots">` entirely. Combining it with `additionalRobotsProps` logs a `console.warn`, but that warning comes from an `$effect` — it does not run during SSR, so on a server-rendered page nothing surfaces at all. Drop one of the two props.
+
+### `openGraph.image` is a shortcut for a single image
+
+```svelte
+<!-- `image` is prepended to `images`; both render as og:image -->
+<MetaTags openGraph={{ image: { url: 'https://example.com/og.jpg' } }} />
+```
+
+If you already build an `images` array, keep using it — but a single-image page doesn't need one.
 
 ## Suggestion (not a bug)
 

--- a/skills/svelte-meta-tags-companion/SKILL.md
+++ b/skills/svelte-meta-tags-companion/SKILL.md
@@ -85,7 +85,7 @@ const metaTags = deepMerge(deepMerge(siteMetaTags, sectionMetaTags), pageMetaTag
 
 TypeScript flags the extra argument, so this only slips through in a `.svelte` file without `lang="ts"` — which is exactly where layout wiring tends to live.
 
-Note also that when both arguments are present, `deepMerge` iterates the source with `Object.entries`, so **symbol keys on the source are dropped**. (If either argument is nullish it short-circuits and returns the other one untouched.) Meta tag props are string-keyed, so this only matters if you are merging your own data through the same helper.
+Note also that when both arguments are present, `deepMerge` iterates the source with `Object.entries`, so **symbol keys on the source are dropped**. (A nullish argument short-circuits the merge entirely: `deepMerge` returns the other argument untouched, or `{}` when both are nullish.) Meta tag props are string-keyed, so this only matters if you are merging your own data through the same helper.
 
 ## Why a tag isn't rendering
 

--- a/skills/svelte-meta-tags-companion/SKILL.md
+++ b/skills/svelte-meta-tags-companion/SKILL.md
@@ -85,7 +85,7 @@ const metaTags = deepMerge(deepMerge(siteMetaTags, sectionMetaTags), pageMetaTag
 
 TypeScript flags the extra argument, so this only slips through in a `.svelte` file without `lang="ts"` — which is exactly where layout wiring tends to live.
 
-Note also that `deepMerge` iterates the source with `Object.entries`, so **symbol keys on the source are dropped**. Meta tag props are string-keyed, so this only matters if you are merging your own data through the same helper.
+Note also that when both arguments are present, `deepMerge` iterates the source with `Object.entries`, so **symbol keys on the source are dropped**. (If either argument is nullish it short-circuits and returns the other one untouched.) Meta tag props are string-keyed, so this only matters if you are merging your own data through the same helper.
 
 ## Why a tag isn't rendering
 

--- a/skills/svelte-meta-tags-setup/SKILL.md
+++ b/skills/svelte-meta-tags-setup/SKILL.md
@@ -1,11 +1,21 @@
 ---
 name: svelte-meta-tags-setup
-description: Use when adding svelte-meta-tags or SEO/meta tag support to a Svelte/SvelteKit project for the first time.
+description: Use when adding svelte-meta-tags, or SEO / meta tag / Open Graph (OGP) / social preview support, to a Svelte/SvelteKit project for the first time.
 ---
 
 # svelte-meta-tags: Setup
 
-## Step 1: Detect whether this is a SvelteKit project
+## Step 1: Install the package
+
+Check whether `svelte-meta-tags` is already in `package.json`. If it isn't, install it as a dev dependency — the components compile into the consuming app, so nothing from this package is needed at runtime:
+
+```sh
+pnpm add -D svelte-meta-tags
+```
+
+Use whichever package manager the project already uses — pick it from the lockfile (`pnpm-lock.yaml` → pnpm, `package-lock.json` → npm, `yarn.lock` → yarn, `bun.lockb` → bun), not from what happens to be installed globally.
+
+## Step 2: Detect whether this is a SvelteKit project
 
 Check for `@sveltejs/kit` in `package.json` dependencies/devDependencies, and for a `src/routes/` directory.
 
@@ -21,9 +31,9 @@ Check for `@sveltejs/kit` in `package.json` dependencies/devDependencies, and fo
 
 Do not introduce `deepMerge`, `defineBaseMetaTags`, or `definePageMetaTags` — those exist specifically for SvelteKit's `load`-based data flow across `+layout.ts`/`+page.ts`, and add unnecessary complexity outside that context.
 
-**If this IS a SvelteKit project**, continue to Step 2.
+**If this IS a SvelteKit project**, continue to Step 3.
 
-## Step 2: Find or create the base layout `load` file
+## Step 3: Find or create the base layout `load` file
 
 Look for `src/routes/+layout.ts` (or `+layout.server.ts` if the project uses server-only data).
 
@@ -47,7 +57,7 @@ export const load = () => {
 };
 ```
 
-## Step 3: Check for nested layouts
+## Step 4: Check for nested layouts
 
 Look for additional `+layout.ts` files in nested route directories (e.g. `src/routes/blog/+layout.ts`). If a section of the site needs its own base tags on top of the root layout's, chain `deepMerge` calls rather than duplicating `defineBaseMetaTags` calls:
 
@@ -68,11 +78,11 @@ export const load: LayoutLoad = async ({ parent }) => {
 };
 ```
 
-When a nested layout overrides `baseMetaTags` like this, wire Step 5 with `page.data.baseMetaTags` instead of `data.baseMetaTags`. A layout's `data` prop only contains its own and ancestor `load` results — a child layout's override never reaches the root layout through `data`. It only surfaces through `page.data`, which merges every `load` on the current page with the deepest one winning.
+When a nested layout overrides `baseMetaTags` like this, wire Step 6 with `page.data.baseMetaTags` instead of `data.baseMetaTags`. A layout's `data` prop only contains its own and ancestor `load` results — a child layout's override never reaches the root layout through `data`. It only surfaces through `page.data`, which merges every `load` on the current page with the deepest one winning.
 
-If there are no nested layouts, skip this step — the standard two-layer (base + page) pattern from Step 2 and Step 4 is enough.
+If there are no nested layouts, skip this step — the standard two-layer (base + page) pattern from Step 3 and Step 5 is enough.
 
-## Step 4: Add page-level tags with `definePageMetaTags`
+## Step 5: Add page-level tags with `definePageMetaTags`
 
 In the relevant `+page.ts` (or `+page.server.ts`), return page-specific overrides:
 
@@ -92,7 +102,7 @@ export const load = () => {
 
 Not every route needs its own `+page.ts` — only add one where the page needs to override the base tags.
 
-## Step 5: Wire up `+layout.svelte`
+## Step 6: Wire up `+layout.svelte`
 
 ```svelte
 <script>
@@ -111,16 +121,16 @@ Not every route needs its own `+page.ts` — only add one where the page needs t
 
 Import `page` from **`$app/state`**, not `$app/stores` — the pre-Svelte-5 API that needs extra reactivity workarounds this pattern doesn't require.
 
-If Step 3 added nested-layout overrides, read the base tags from `page.data` instead, so section-level overrides actually reach this component:
+If Step 4 added nested-layout overrides, read the base tags from `page.data` instead, so section-level overrides actually reach this component:
 
 ```js
 let metaTags = $derived(deepMerge(page.data.baseMetaTags, page.data.pageMetaTags));
 ```
 
-## Step 6: JSON-LD (optional)
+## Step 7: JSON-LD (optional)
 
 If the project needs structured data (e.g. for rich search results), mention that `<JsonLd schema={...} />` exists as a separate component and point to https://oekazuma.github.io/svelte-meta-tags/json-ld/ for details — don't design a JSON-LD schema as part of this setup flow.
 
-## Step 7: Verify
+## Step 8: Verify
 
 Run the project's typecheck command (e.g. `pnpm check`, `svelte-check`, or whatever `package.json` defines) and confirm it passes with no new errors before considering the setup done.

--- a/skills/svelte-meta-tags-setup/SKILL.md
+++ b/skills/svelte-meta-tags-setup/SKILL.md
@@ -7,13 +7,18 @@ description: Use when adding svelte-meta-tags, or SEO / meta tag / Open Graph (O
 
 ## Step 1: Install the package
 
-Check whether `svelte-meta-tags` is already in `package.json`. If it isn't, install it as a dev dependency — the components compile into the consuming app, so nothing from this package is needed at runtime:
+Check whether `svelte-meta-tags` is already in `package.json`. If it is, skip to Step 2.
 
-```sh
-pnpm add -D svelte-meta-tags
-```
+If it isn't, pick the command from the project's lockfile — not from whatever package manager happens to be installed globally:
 
-Use whichever package manager the project already uses — pick it from the lockfile (`pnpm-lock.yaml` → pnpm, `package-lock.json` → npm, `yarn.lock` → yarn, `bun.lockb` → bun), not from what happens to be installed globally.
+| Lockfile                               | Command                                   |
+| -------------------------------------- | ----------------------------------------- |
+| `pnpm-lock.yaml`                       | `pnpm add -D svelte-meta-tags`            |
+| `package-lock.json`                    | `npm install --save-dev svelte-meta-tags` |
+| `yarn.lock`                            | `yarn add --dev svelte-meta-tags`         |
+| `bun.lock` (or the legacy `bun.lockb`) | `bun add --dev svelte-meta-tags`          |
+
+Install it as a **dev** dependency: the components compile into the consuming app, so nothing from this package is needed at runtime.
 
 ## Step 2: Detect whether this is a SvelteKit project
 

--- a/skills/svelte-meta-tags-setup/SKILL.md
+++ b/skills/svelte-meta-tags-setup/SKILL.md
@@ -18,6 +18,8 @@ If it isn't, pick the command from the project's lockfile — not from whatever 
 | `yarn.lock`                            | `yarn add --dev svelte-meta-tags`         |
 | `bun.lock` (or the legacy `bun.lockb`) | `bun add --dev svelte-meta-tags`          |
 
+If none of these lockfiles exists, fall back to the `packageManager` field in `package.json`; if that is absent too, ask which package manager to use rather than guessing.
+
 Install it as a **dev** dependency: the components compile into the consuming app, so nothing from this package is needed at runtime.
 
 ## Step 2: Detect whether this is a SvelteKit project


### PR DESCRIPTION
## Background

I read both distributed Agent Skills (`npx skills add`) against the library source. Two things were off: a step the setup flow never had, and the failure mode the companion skill doesn't cover.

## Setup skill

**There was no install step.** The description says "adding svelte-meta-tags ... for the first time", yet Steps 1–7 went straight to `import { defineBaseMetaTags } from 'svelte-meta-tags'`. On a project without the package, an agent following the skill only finds out at the final typecheck.

The new step goes ahead of the SvelteKit detection branch, because the non-SvelteKit path imports `MetaTags` too. It leads with a lockfile → command table (`pnpm-lock.yaml`, `package-lock.json`, `yarn.lock`, `bun.lock`), falls back to `package.json`'s `packageManager` field, and asks rather than guessing when neither exists. The remaining steps are renumbered 2–8, cross-references included.

The description also picked up `Open Graph (OGP)` and `social preview` so it matches how people actually phrase the request.

## Companion skill

The four existing entries all describe *writing wrong code*. What this library actually produces is **correct-looking props that render nothing**, so those cases now have their own section, `## Why a tag isn't rendering`:

| Behavior | Why |
| --- | --- |
| No `og:*` or `twitter:*` tag at all unless the `openGraph` / `twitter` prop is present — the documented fallbacks only apply inside those blocks | `{#if openGraph}` / `{#if twitter}` |
| `titleTemplate` without `title` renders no `<title>` | falsy `title` returns early |
| Falsy robots directives are dropped: `maxSnippet: 0` emits nothing, `-1` works | each directive is truthy-checked |
| `robots={false}` suppresses the tag, and the `additionalRobotsProps` warning comes from an `$effect`, so it never fires during SSR | `$effect` + `{#if robots !== false}` |
| `openGraph.image` (singular) is an alias prepended to `images` | `[openGraph.image, ...images]` |

Common mistakes gained a fifth entry: `deepMerge` takes exactly `(target, source)`, so a third argument is dropped silently. TypeScript catches it, but layout wiring often lives in a `.svelte` file without `lang="ts"`. The existing "defined precedence rules for `Date`/function values" is now specific — the **target** wins, the reverse of the usual source-wins rule — and the symbol-key gap is noted.

## Verification

- `pnpm lint` passes (Prettier / ESLint / `validate-skills`)
- Every behavior documented here was read off `MetaTags.svelte` and `deepMerge.ts` on `origin/main`

No changeset: `skills/` is not part of the published package (`files: ["dist"]`), same as #2173.

## Related

The two behaviors that were missing from the docs as well are covered separately in #2232.

🤖 Generated with [Claude Code](https://claude.com/claude-code)