### PR TITLE
docs: document that og/twitter tags need their prop, and that falsy robots directives drop

### DIFF
--- a/docs/content/ja/meta-tags-properties/additional-robots-props.md
+++ b/docs/content/ja/meta-tags-properties/additional-robots-props.md
@@ -40,4 +40,6 @@ sidebar:
 | `noimageindex`     | boolean                   | このページの画像をインデックスしない                                                                                                                                                        |
 | `unavailableAfter` | string                    | 指定した日付/時刻以降はこのページを検索結果に表示しません。日付/時刻は、RFC 822、RFC 850、ISO 8601 など、広く受け入れられている形式でなければなりません                                     |
 
+各ディレクティブは値が truthy な場合にのみ出力されるため、`0` は出力されません（`maxSnippet: 0` と `maxVideoPreview: 0` は何も出力しません）。テキストスニペットを抑止する場合は `nosnippet: true` を、画像プレビューを抑止する場合は `maxImagePreview: 'none'` を使用してください。
+
 `X-Robots-Tag` の詳細については、[Google 検索セントラル - クロールとインデックス登録の制御](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=ja#directives) をご覧ください。

--- a/docs/content/ja/meta-tags-properties/twitter.md
+++ b/docs/content/ja/meta-tags-properties/twitter.md
@@ -22,6 +22,8 @@ twitter={{
 
 ## フォールバック動作
 
+`twitter` プロパティを渡さない限り、`twitter:*` タグは 1 つも出力されません。以下のフォールバックは `twitter` ブロックの内側で機能するものであり、プロパティ自体の代わりにはなりません。カードを出力するには、最低でも `twitter={{ cardType: 'summary' }}` を渡してください。
+
 `twitter` プロパティで `twitter.title` や `twitter.description` が明示的に設定されていない場合、他の利用可能な値に自動的にフォールバックします:
 
 - `twitter.title` → `openGraph.title` → `title`

--- a/docs/content/ja/open-graph/basic.md
+++ b/docs/content/ja/open-graph/basic.md
@@ -4,6 +4,8 @@ sidebar:
   order: 20
 ---
 
+`openGraph` プロパティを渡さない限り、`og:*` タグは 1 つも出力されません。`og:title` は `title` に、`og:description` は `description` にフォールバックしますが、これらは `openGraph` ブロックの内側でのみ機能するため、`title` と `description` だけを設定したページには OpenGraph タグが一切出力されません。フォールバックだけを利用したい場合は `openGraph={{}}` を渡してください。
+
 ```svelte
 <script>
   import { MetaTags } from 'svelte-meta-tags';

--- a/docs/content/meta-tags-properties/additional-robots-props.md
+++ b/docs/content/meta-tags-properties/additional-robots-props.md
@@ -40,4 +40,6 @@ In addition to `index, follow` the `robots` meta tag accepts more properties to 
 | `noimageindex`     | boolean                   | Do not index images on this page                                                                                                                                                               |
 | `unavailableAfter` | string                    | Do not show this page in search results after the specified date/time. The date/time must be in a widely accepted format, including but not limited to RFC 822, RFC 850, and ISO 8601          |
 
+Each directive is emitted only when its value is truthy, so `0` is dropped: `maxSnippet: 0` and `maxVideoPreview: 0` render nothing. Use `nosnippet: true` to suppress the text snippet, and `maxImagePreview: 'none'` to suppress the image preview.
+
 For more information on the `X-Robots-Tag` visit [Google Search Central - Control Crawling and Indexing](https://developers.google.com/search/reference/robots_meta_tag?hl=en-GB#directives)

--- a/docs/content/meta-tags-properties/twitter.md
+++ b/docs/content/meta-tags-properties/twitter.md
@@ -22,6 +22,8 @@ twitter={{
 
 ## Fallback Behavior
 
+No `twitter:*` tag is rendered unless the `twitter` prop is present — the fallbacks below apply inside that block, not in place of it. Pass at least `twitter={{ cardType: 'summary' }}` to render the card.
+
 When `twitter.title` or `twitter.description` is not explicitly set in the `twitter` prop, they automatically fall back to other available values:
 
 - `twitter.title` → `openGraph.title` → `title`

--- a/docs/content/open-graph/basic.md
+++ b/docs/content/open-graph/basic.md
@@ -4,6 +4,8 @@ sidebar:
   order: 20
 ---
 
+No `og:*` tag is rendered unless the `openGraph` prop is present. `og:title` falls back to `title` and `og:description` to `description`, but those fallbacks only apply inside the `openGraph` block — a page that sets just `title` and `description` emits no OpenGraph tags. Pass `openGraph={{}}` to opt in on the fallbacks alone.
+
 ```svelte
 <script>
   import { MetaTags } from 'svelte-meta-tags';


### PR DESCRIPTION
## Background

Of the behaviors written into the Agent Skills in #2231, **two were missing from the docs as well**. This adds them in both locales.

## 1. `og:*` and `twitter:*` need their prop to exist at all

`MetaTags.svelte` guards the entire OpenGraph block behind `{#if openGraph}` and the Twitter block behind `{#if twitter}`. The fallbacks — `og:title` → `title`, `twitter.title` → `openGraph.title` → `title` — apply *inside* those blocks, so a page that sets only `title` and `description` emits no social tags at all.

[Open Graph / Basic](https://oekazuma.github.io/svelte-meta-tags/open-graph/basic) and the [Twitter fallback section](https://oekazuma.github.io/svelte-meta-tags/meta-tags-properties/twitter) currently describe the fallbacks without naming that precondition, which reads as if they apply unconditionally. Both pages get one paragraph stating it.

## 2. Falsy `additionalRobotsProps` values are dropped

Each directive is emitted only when its value is truthy, so `maxSnippet: 0` and `maxVideoPreview: 0` render nothing while `-1` works.

`0` is a valid value in Google's own reference ("do not show a text snippet"), so someone who sets it deliberately has no way to notice. The note sits under the property table, along with the alternatives that do work (`nosnippet: true`, `maxImagePreview: 'none'`).

## Already documented, so not included

I had also expected `titleTemplate` alone rendering no `<title>` to be missing — it isn't. [Basic](https://oekazuma.github.io/svelte-meta-tags/meta-tags-properties/basic) already states it in both locales: "If `title` is not set, `titleTemplate` alone renders no `<title>` tag at all." The `robots={false}` warning and the `openGraph.image` shortcut are likewise already covered.

## Verification

- `pnpm --filter docs build` passes, including link and navigation diagnostics
- `pnpm lint` passes
- Both behaviors were read off `MetaTags.svelte` on `origin/main`

No file overlap with #2231, so either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)