### PR TITLE
ci: replace pnpm/action-setup + actions/setup-node with pnpm/setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,6 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Setup Node.js and dependencies
         uses: ./.github/workflows/setup-node
-        with:
-          registry-url: 'https://registry.npmjs.org'
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1

--- a/.github/workflows/setup-node/action.yml
+++ b/.github/workflows/setup-node/action.yml
@@ -1,36 +1,12 @@
 name: 'Setup Node.js and pnpm'
-description: 'Install pnpm, set up Node.js using version from package.json devEngines, and install dependencies'
-
-inputs:
-  registry-url:
-    description: 'Optional npm registry URL for publishing'
-    required: false
-    default: ''
+description: 'Install pnpm and Node.js from package.json (packageManager / devEngines) and install dependencies'
 
 runs:
   using: 'composite'
   steps:
-    - name: Get Node.js version from package.json
-      id: get-node-version
-      shell: bash
-      run: |
-        NODE_VERSION=$(jq -r '.devEngines.runtime.version' package.json)
-        if [ -z "$NODE_VERSION" ] || [ "$NODE_VERSION" = "null" ]; then
-          echo "::error::Could not extract devEngines.runtime.version from package.json"
-          exit 1
-        fi
-        echo "node-version=${NODE_VERSION}" >> "$GITHUB_OUTPUT"
-
-    - name: Install pnpm
-      uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-
-    - name: Setup Node.js
-      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+    # Installs only `node`, no `npm`; anything that shells out to npm gets the runner image's copy.
+    - name: Install pnpm, Node.js and dependencies
+      uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
       with:
-        node-version: ${{ steps.get-node-version.outputs.node-version }}
-        cache: 'pnpm'
-        registry-url: ${{ inputs.registry-url }}
-
-    - name: Install dependencies
-      shell: bash
-      run: pnpm install --frozen-lockfile
+        cache: true
+        require-lockfile: true


### PR DESCRIPTION
## Summary

Collapses the `setup-node` composite action to a single [`pnpm/setup@v2.1.0`](https://github.com/pnpm/setup) step (SHA-pinned), replacing `pnpm/action-setup` + `actions/setup-node`. Same change as oekazuma/svelte-vitals#662.

- `pnpm/setup` installs pnpm (from `packageManager`) and Node (from `devEngines.runtime`) in one step and runs `pnpm install --no-runtime` itself, so the jq `devEngines` lookup and the manual install step are gone.
- `cache: true` replaces `actions/setup-node`'s `cache: 'pnpm'`; `require-lockfile: true` replaces the explicit `--frozen-lockfile`.
- `registry-url` is dropped from the action and `release.yml`. No `NODE_AUTH_TOKEN` exists anywhere and changesets publishes through OIDC (`id-token: write` + `NPM_CONFIG_PROVENANCE`), so the `.npmrc` `actions/setup-node` generated was never used.
- No `runtime` input: this repo has no Node matrix, so every caller (`ci.yml`, `release.yml`, `deploy-docs.yml`) uses the `devEngines` pin as-is.

## Verification

- `pnpm prettier --check .github` and YAML parse: pass.
- The v2.1.0 tag was dereferenced via the GitHub API to confirm the pinned SHA.

## Things to watch on the first runs

- First CI run is a one-time pnpm store cache miss (new cache key namespace).
- `pnpm/setup` installs only `node`, not `npm`. `changeset publish` detects `pnpm-lock.yaml` and uses `pnpm publish`, so this should be unaffected, but the next release run is the proof.

No changeset: CI-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the project’s automated setup for more consistent Node.js and pnpm installation.
  - Improved dependency caching and lockfile validation during automated workflows.
  - Simplified release workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->